### PR TITLE
Add pre-commit hook check-executables-have-shebangs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,7 @@ repos:
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
+      - id: check-executables-have-shebangs
       - id: check-illegal-windows-names
       - id: check-merge-conflict
       - id: check-shebang-scripts-are-executable


### PR DESCRIPTION
https://github.com/pre-commit/pre-commit-hooks?tab=readme-ov-file#check-executables-have-shebangs