### PR TITLE
Fix mixed-line-ending pre-commit hook configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,6 +68,7 @@ repos:
       - id: fix-byte-order-marker
       - id: forbid-submodules
       - id: mixed-line-ending
+        args: ['--fix=lf']
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
   - repo: https://github.com/codespell-project/codespell

--- a/output.salam
+++ b/output.salam
@@ -94,7 +94,8 @@ Char: 'm' (0x6D)
 Char: 'e' (0x65)
 Char: 'n' (0x6E)
 Char: 't' (0x74)
-Char: '' (0x0D)
+Char: '
+' (0x0D)
 Char: '
 ' (0x0A)
 Char: 'f' (0x66)
@@ -105,7 +106,8 @@ Char: 'a' (0x61)
 Char: 'i' (0x69)
 Char: 'n' (0x6E)
 Char: ':' (0x3A)
-Char: '' (0x0D)
+Char: '
+' (0x0D)
 Char: '
 ' (0x0A)
 Char: ' ' (0x20)
@@ -114,7 +116,8 @@ Char: ' ' (0x20)
 Char: ' ' (0x20)
 Char: '/' (0x2F)
 Char: '*' (0x2A)
-Char: '' (0x0D)
+Char: '
+' (0x0D)
 Char: '
 ' (0x0A)
 Char: ' ' (0x20)
@@ -138,7 +141,8 @@ Char: 'g' (0x67)
 Char: 'o' (0x6F)
 Char: 'd' (0x64)
 Char: 'f' (0x66)
-Char: '' (0x0D)
+Char: '
+' (0x0D)
 Char: '
 ' (0x0A)
 Char: ' ' (0x20)
@@ -151,7 +155,8 @@ Char: ' ' (0x20)
 Char: ' ' (0x20)
 Char: 'g' (0x67)
 Char: 'd' (0x64)
-Char: '' (0x0D)
+Char: '
+' (0x0D)
 Char: '
 ' (0x0A)
 Char: ' ' (0x20)
@@ -169,7 +174,8 @@ Char: 'k' (0x6B)
 Char: 'o' (0x6F)
 Char: 'f' (0x66)
 Char: 'g' (0x67)
-Char: '' (0x0D)
+Char: '
+' (0x0D)
 Char: '
 ' (0x0A)
 Char: ' ' (0x20)
@@ -200,7 +206,8 @@ Char: 'k' (0x6B)
 Char: 'o' (0x6F)
 Char: 'g' (0x67)
 Char: '"' (0x22)
-Char: '' (0x0D)
+Char: '
+' (0x0D)
 Char: '
 ' (0x0A)
 Char: ' ' (0x20)
@@ -223,7 +230,8 @@ Char: 'f' (0x66)
 Char: 'g' (0x67)
 Char: '*' (0x2A)
 Char: '/' (0x2F)
-Char: '' (0x0D)
+Char: '
+' (0x0D)
 Char: '
 ' (0x0A)
 Char: ' ' (0x20)
@@ -244,7 +252,8 @@ Char: '1' (0x31)
 Char: '1' (0x31)
 Char: '1' (0x31)
 Char: '0' (0x30)
-Char: '' (0x0D)
+Char: '
+' (0x0D)
 Char: '
 ' (0x0A)
 Char: ' ' (0x20)
@@ -253,7 +262,8 @@ Char: ' ' (0x20)
 Char: ' ' (0x20)
 Char: '*' (0x2A)
 Char: '/' (0x2F)
-Char: '' (0x0D)
+Char: '
+' (0x0D)
 Char: '
 ' (0x0A)
 Char: ' ' (0x20)
@@ -271,7 +281,8 @@ Char: ' ' (0x20)
 Char: '9' (0x39)
 Char: '9' (0x39)
 Char: '9' (0x39)
-Char: '' (0x0D)
+Char: '
+' (0x0D)
 Char: '
 ' (0x0A)
 Char: ' ' (0x20)
@@ -291,7 +302,8 @@ Char: ' ' (0x20)
 Char: '+' (0x2B)
 Char: ' ' (0x20)
 Char: '5' (0x35)
-Char: '' (0x0D)
+Char: '
+' (0x0D)
 Char: '
 ' (0x0A)
 Char: '/' (0x2F)
@@ -311,13 +323,15 @@ Char: 'h' (0x68)
 Char: 'e' (0x65)
 Char: 'y' (0x79)
 Char: '"' (0x22)
-Char: '' (0x0D)
+Char: '
+' (0x0D)
 Char: '
 ' (0x0A)
 Char: 'e' (0x65)
 Char: 'n' (0x6E)
 Char: 'd' (0x64)
-Char: '' (0x0D)
+Char: '
+' (0x0D)
 Char: '
 ' (0x0A)
 Source: '// single line comment


### PR DESCRIPTION

### Description

This pull request updates the mixed-line-ending pre-commit hook configuration to enforce consistent Unix-style (LF) line endings and fixes mixed line endings in `output.salam`.

### Related Issue

Resolves #1057

### Proposed Changes

- Add `args: ['--fix=lf']` to the `mixed-line-ending` hook in `.pre-commit-config.yaml`
- Normalize all line endings in `output.salam` to LF

### Checklist

- [x] I have tested these changes locally.
- [x] My code follows the project's coding style guidelines.
- [x] I have reviewed my own code to ensure quality.
- [x] Unnecessary comments were removed.

### Additional Notes

This ensures all files have consistent line endings and prevents future mixed line ending issues.