### PR TITLE
Update generate_files.py

### DIFF
--- a/generate_files.py
+++ b/generate_files.py
@@ -94,7 +94,10 @@ def create_c_and_h_files_for_empty_directory(directory, root):
 
 
 def scan_directory(root):
+    IGNORE_DIRS = {".git", "__pycache__", ".vscode", "build", "out"}
+
     for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in IGNORE_DIRS]
         for filename in filenames:
             if filename.endswith(".c"):
                 c_file_path = os.path.join(dirpath, filename)


### PR DESCRIPTION
I checked those Python files, and the problem was coming from the scan_directory function, which was writing files without any exclude rules. I added a list of directories that should be ignored — including .git — and I felt it would be better to include a few others as well. The following lines also handle the checks, and overall the issue should no longer occur.

cc @BaseMax #1127 