### PR TITLE
Modify Dependabot settings for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,13 @@
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 version: 2
 updates:
-  - package-ecosystem: 'github-actions' # See documentation for possible values
-    directory: '/' # Location of package manifests
+  - package-ecosystem: github-actions
+    directory: /
+    open-pull-requests-limit: 2
     schedule:
-      interval: 'daily'
-  - package-ecosystem: 'pip'
-    directory: '/'
-    schedule:
-      interval: 'daily'
+      interval: monthly
+    groups:
+      github-actions-dependencies:
+        patterns:
+          - '*'
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Updated Dependabot configuration for GitHub Actions to limit open pull requests and change schedule to monthly.
