### PR TITLE
Enforce LF line endings for text and YAML files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,10 +11,8 @@
 
 # Force batch scripts to always use CRLF line endings so that if a repo is accessed
 # in Windows via a file share from Linux, the scripts will work.
-*.cmd text eol=crlf
-*.CMD text eol=crlf
-*.bat text eol=crlf
-*.BAT text eol=crlf
+*.[cC][mM][dD] text eol=crlf
+*.[bB][aA][tT] text eol=crlf
 
 # Force bash scripts to always use LF line endings so that if a repo is accessed
 # in Unix via a file share from Windows, the scripts will work.

--- a/.gitattributes
+++ b/.gitattributes
@@ -11,8 +11,10 @@
 
 # Force batch scripts to always use CRLF line endings so that if a repo is accessed
 # in Windows via a file share from Linux, the scripts will work.
-*.{cmd,[cC][mM][dD]} text eol=crlf
-*.{bat,[bB][aA][tT]} text eol=crlf
+*.cmd text eol=crlf
+*.CMD text eol=crlf
+*.bat text eol=crlf
+*.BAT text eol=crlf
 
 # Force bash scripts to always use LF line endings so that if a repo is accessed
 # in Unix via a file share from Windows, the scripts will work.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,12 +1,19 @@
 ###############################
 # Git Line Endings            #
 ###############################
-# Set default behaviour to automatically normalize line endings.
-* text=auto
+
+# Enforce LF line endings for all text files to prevent CRLF issues on Windows
+* text=auto eol=lf
+
+# Explicitly enforce LF for YAML files (prevents yamllint failures on Windows)
+*.yaml text eol=lf
+*.yml text eol=lf
+
 # Force batch scripts to always use CRLF line endings so that if a repo is accessed
 # in Windows via a file share from Linux, the scripts will work.
 *.{cmd,[cC][mM][dD]} text eol=crlf
 *.{bat,[bB][aA][tT]} text eol=crlf
+
 # Force bash scripts to always use LF line endings so that if a repo is accessed
 # in Unix via a file share from Windows, the scripts will work.
 *.sh text eol=lf


### PR DESCRIPTION
Updated line endings configuration to enforce LF for all text files and explicitly for YAML files.
