### PR TITLE
Change link in README to a placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 
 <p>
-    <a href="https://salamlang.ir/">
+    <a href="#">
         <img width="150" src="https://raw.githubusercontent.com/SalamLang/Salam/main/design/logo/logo-box.svg" alt="The Salam Programming Language - زبان برنامه نویسی سلام">
     </a>
 </p>
@@ -192,6 +192,5 @@ We welcome contributions from the community!
 - 🌟 Follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 Together, let’s make coding accessible to all.
-For inquiries or feedback, visit: [salamlang.ir](https://salamlang.ir)
 
 © 2024-2026 Salam Language Team

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 <div align="center">
 
 <p>
-    <a href="#">
-        <img width="150" src="https://raw.githubusercontent.com/SalamLang/Salam/main/design/logo/logo-box.svg" alt="The Salam Programming Language - زبان برنامه نویسی سلام">
-    </a>
+    <img width="150" src="https://raw.githubusercontent.com/SalamLang/Salam/main/design/logo/logo-box.svg" alt="The Salam Programming Language - زبان برنامه نویسی سلام">
 </p>
 
 # Salam Programming Language


### PR DESCRIPTION
Updated the link in the README to point to a placeholder instead of the actual website.
