### PR TITLE
fix: enforce eol=lf in extensions/vscode/.gitattributes

### DIFF
--- a/extensions/vscode/.gitattributes
+++ b/extensions/vscode/.gitattributes
@@ -1,2 +1,2 @@
 # Set default behavior to automatically normalize line endings.
-* text=auto
+* text=auto eol=lf


### PR DESCRIPTION
### Description

Added `eol=lf` to `extensions/vscode/.gitattributes` to enforce consistent LF line endings. Previously `* text=auto` overrode the root `.gitattributes`, allowing CRLF on Windows.

### Related Issue

Closes #1209

### Proposed Changes

- Changed `* text=auto` to `* text=auto eol=lf` in extensions/vscode/.gitattributes

### Checklist

- [x] I have tested these changes locally.
- [x] My code follows the project's coding style guidelines.
- [x] I have reviewed my own code to ensure quality.
- [x] Unnecessary comments were removed.

### Additional Notes

None

