### PR TITLE
Remove macOS 14 from workflow OS matrix for Prek Manual Hooks

### DIFF
--- a/.github/workflows/prek-manual.yml
+++ b/.github/workflows/prek-manual.yml
@@ -24,7 +24,6 @@ jobs:
           - { os: ubuntu-slim }
           - { os: macos-26 }
           - { os: macos-15 }
-          - { os: macos-14 }
           - { os: windows-2025-vs2026 }
           - { os: windows-2025 }
           - { os: windows-2022 }


### PR DESCRIPTION
Removed macOS 14 from the workflow matrix.

fixes https://github.com/SalamLang/Salam/issues/1292
