### PR TITLE
Make the web assembly build always run on PRs

### DIFF
--- a/.github/workflows/web-assembly-build-on-prs.yml
+++ b/.github/workflows/web-assembly-build-on-prs.yml
@@ -2,16 +2,8 @@
 name: 🌐 Build WebAssembly on PRs
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
     branches:
       - main
-    paths:
-      - 'compiler/src/**'
-      - 'compiler/std/**'
-      - 'compiler/tools/**'
-      - 'editor/**'
-      - 'examples/**'
-      - '.github/workflows/web-assembly-build-on-prs.yml'
 permissions:
   contents: read
 concurrency:


### PR DESCRIPTION
Removed specific pull request types and paths for the WebAssembly build workflow.
