### PR TITLE
Fix/arabic terms for the playground

### DIFF
--- a/editor/app.js
+++ b/editor/app.js
@@ -94,8 +94,8 @@
       theme_dark: "داكن",
       view_run: "تشغيل",
       view_tokens: "علامات",
-      view_ast: "شجرة نحوية مجردة",// Source: wikipedia -
-      view_symbols: "رموز", //symbols
+      view_ast: "شجرة نحوية مجردة",
+      view_symbols: "رموز",
       view_html: "HTML",
       view_css: "CSS",
       view_js: "JS",

--- a/editor/app.js
+++ b/editor/app.js
@@ -73,7 +73,7 @@
     ar: {
       title: "ملعب سلام",//I prefered the term 'Malaab' which tells more on the playground term
       mode_app: "التطبيق",//I better translation of the term App.
-      mode_layout: "المخطط",//
+      mode_layout: "المخطط",
       run: "تشغيل",
       autorun: "تشغيل تلقائي",
       editor: "المحرر",

--- a/editor/app.js
+++ b/editor/app.js
@@ -88,7 +88,7 @@
       examples: "أمثلة",
       g_console: "لوحة تحكم البرنامج",
       g_web: "صفحات الويب",
-      badge_web: "الويب",//Adding the preposition AL
+      badge_web: "الويب",
       theme_auto: "تلقائي",
       theme_light: "فاتح",
       theme_dark: "داكن",

--- a/editor/app.js
+++ b/editor/app.js
@@ -71,9 +71,9 @@
       copied: "کپی شد",
     },
     ar: {
-      title: "ساحة سلام",
-      mode_app: "برنامج",
-      mode_layout: "تخطيط",
+      title: "ملعب سلام",//I prefered the term 'Malaab' which tells more on the playground term
+      mode_app: "التطبيق",//I better translation of the term App.
+      mode_layout: "المخطط",//
       run: "تشغيل",
       autorun: "تشغيل تلقائي",
       editor: "المحرر",
@@ -86,16 +86,16 @@
       loading: "تحميل المترجم…",
       custom: "مخصص",
       examples: "أمثلة",
-      g_console: "برامج طرفية",
-      g_web: "صفحات وب",
-      badge_web: "وب",
+      g_console: "لوحة تحكم البرنامج",
+      g_web: "صفحات الويب",
+      badge_web: "الويب",//Adding the preposition AL
       theme_auto: "تلقائي",
       theme_light: "فاتح",
       theme_dark: "داكن",
       view_run: "تشغيل",
-      view_tokens: "الرموز",
-      view_ast: "الشجرة",
-      view_symbols: "الرموز البرمجية",
+      view_tokens: "علامات",
+      view_ast: "شجرة نحوية مجردة",// Source: wikipedia -
+      view_symbols: "رموز", //symbols
       view_html: "HTML",
       view_css: "CSS",
       view_js: "JS",

--- a/editor/app.js
+++ b/editor/app.js
@@ -71,8 +71,8 @@
       copied: "کپی شد",
     },
     ar: {
-      title: "ملعب سلام",//I prefered the term 'Malaab' which tells more on the playground term
-      mode_app: "التطبيق",//I better translation of the term App.
+      title: "ملعب سلام",
+      mode_app: "التطبيق",
       mode_layout: "المخطط",
       run: "تشغيل",
       autorun: "تشغيل تلقائي",


### PR DESCRIPTION
### Description

I adjusted some Arabic terms in the playground

### Related Issue

[[If this pull request addresses or resolves an existing issue, please reference it here.](https://github.com/SalamLang/Salam/issues/13#issuecomment-4884259203)](https://github.com/SalamLang/Salam/issues/13#issuecomment-4884259203)

### Proposed Changes

Changed some terms in the Arabic section: [/editor/app.js](https://github.com/SalamLang/Salam/blob/main/editor/app.js)

 ar: {
      title: "ملعب سلام",//I prefered the term 'Malaab' which tells more on the playground term
      mode_app: "التطبيق",//I better translation of the term App.
      mode_layout: "المخطط",
      run: "تشغيل",
      autorun: "تشغيل تلقائي",
      editor: "المحرر",
      output: "الإخراج",
      preview: "معاينة",
      ready: "جاهز",
      running: "قيد التشغيل…",
      done: "تم",
      error: "خطأ",
      loading: "تحميل المترجم…",
      custom: "مخصص",
      examples: "أمثلة",
      g_console: "لوحة تحكم البرنامج",
      g_web: "صفحات الويب",
      badge_web: "الويب",//Adding the preposition AL
      theme_auto: "تلقائي",
      theme_light: "فاتح",
      theme_dark: "داكن",
      view_run: "تشغيل",
      view_tokens: "علامات",
      view_ast: "شجرة نحوية مجردة",// Source: wikipedia -
      view_symbols: "رموز", //symbols
      view_html: "HTML",
      view_css: "CSS",
      view_js: "JS",
      view_c: "كود C",
      view_llvm: "LLVM IR",
      copy: "نسخ",
      copied: "تم النسخ",
    },

### Checklist


### Additional Notes

needs additional review.
