### PR TITLE
Remove Windows 11 ARM from lint workflow prek standard

### DIFF
--- a/.github/workflows/lint-prek.yml
+++ b/.github/workflows/lint-prek.yml
@@ -27,7 +27,6 @@ jobs:
           - { os: windows-2025-vs2026 }
           - { os: windows-2025 }
           - { os: windows-2022 }
-          - { os: windows-11-arm }
     steps:
       - name: 'Checkout ${{ github.ref }} ( ${{ github.sha }} )'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
Always fails for biome
