### PR TITLE
docs: add CITATION.cff for Salam software

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,59 @@
+cff-version: 1.2.0
+title: Salam
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+license: GPL-3.0
+repository-code: https://github.com/SalamLang/Salam
+url: https://salamlang.github.io/Salam/
+abstract: >-
+  Salam is a general-purpose and systems programming language designed for
+  efficient software development, featuring a built-in domain-specific
+  language (DSL) for web development. It is statically typed, transpiles to
+  C, and supports native compilation as well as a layout DSL for building
+  HTML/CSS/JS web pages.
+keywords:
+  - programming-language
+  - compiler
+  - transpiler
+  - interpreter
+  - scripting
+  - dsl
+  - community
+  - linguistics
+  - persian
+  - arabic
+authors:
+  - family-names: Mohammadiyeh
+    given-names: Seyyed Ali
+    alias: BaseMax
+    affiliation: SalamLang
+    orcid: https://orcid.org/0000-0000-0000-0000
+  - family-names: Bampton
+    given-names: John
+    alias: jbampton
+    affiliation: SalamLang
+identifiers:
+  - type: url
+    value: https://github.com/SalamLang/Salam
+    description: GitHub repository
+version: 0.2.9
+date-released: 2026-08-14
+contact:
+  - family-names: Mohammadiyeh
+    given-names: Seyyed Ali
+    email: maxbasecode@gmail.com
+    alias: BaseMax
+references:
+  - type: software
+    title: Salam Online Playground
+    authors:
+      - alias: SalamLang
+    repository-code: https://github.com/SalamLang/Salam/tree/main/editor
+    url: https://salamlang.github.io/Salam/
+  - type: software
+    title: Salam VS Code Extension
+    authors:
+      - alias: salamlanguage
+    url: https://marketplace.visualstudio.com/items?itemName=salamlanguage.salam-programming-language


### PR DESCRIPTION
## Summary

Adds a `CITATION.cff` file at the repository root using the
[Citation File Format (CFF) v1.2.0](https://citation-file-format.github.io/)
so users can correctly cite the Salam software.

When GitHub detects a `CITATION.cff` file, it automatically displays a
"**Cite this repository**" link in the repository sidebar, providing
pre-formatted citations in APA and BibTeX formats. CFF files also
integrate with Zenodo for automatic DOI assignment on each new release.

## Changes

- New file: `CITATION.cff` at the repository root
- Includes metadata: title, version (0.2.9), release date (2026-08-14),
  authors (Seyyed Ali Mohammadiyeh / Max Base, John Bampton), license
  (GPL-3.0), keywords, and references to the playground & VS Code
  extension.

## Motivation

Closes #1296

## Validation

- YAML parses cleanly
- CFF schema fields populated per the CFF v1.2.0 specification
- Authors match the public maintainer list in the org profile
- Version and release date match the latest release (`v0.2.9`,
  2026-08-14)

## References

- [About CITATION files — GitHub Docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files)
- [Citation File Format — CFF](https://citation-file-format.github.io/)