### PR TITLE
fix(docs): align MySTMD badge labels with their alt text (closes #1451)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Salam is a general-purpose and systems programming language designed for efficie
 [![PR - Pull Request Labeler](https://github.com/SalamLang/Salam/actions/workflows/pr-labeler.yml/badge.svg)](https://github.com/SalamLang/Salam/actions/workflows/pr-labeler.yml)
 [![Dependabot Updates](https://github.com/SalamLang/Salam/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/SalamLang/Salam/actions/workflows/dependabot/dependabot-updates)
 [![GitHub Pages Build Deployment](https://github.com/SalamLang/Salam/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/SalamLang/Salam/actions/workflows/pages/pages-build-deployment)
-[![VS Code Marketplace Version](https://vsmarketplacebadges.dev/version/salamlanguage.salam-programming-language.svg)](https://marketplace.visualstudio.com/items?itemName=salamlanguage.salam-programming-language)
-[![VS Code Marketplace Installs](https://vsmarketplacebadges.dev/installs/salamlanguage.salam-programming-language.svg)](https://marketplace.visualstudio.com/items?itemName=salamlanguage.salam-programming-language)
+[![VS Code Marketplace Version](https://vsmarketplacebadges.dev/version/salamlanguage.salam-programming-language.svg?label=VS%20Code%20Marketplace%20Version)](https://marketplace.visualstudio.com/items?itemName=salamlanguage.salam-programming-language)
+[![VS Code Marketplace Installs](https://vsmarketplacebadges.dev/installs/salamlanguage.salam-programming-language.svg?label=VS%20Code%20Marketplace%20Installs)](https://marketplace.visualstudio.com/items?itemName=salamlanguage.salam-programming-language)
 
 ---
 
@@ -88,7 +88,7 @@ powershell -NoProfile -Command "[Net.ServicePointManager]::SecurityProtocol = [N
 
 Install the official Salam Language extension from the [Visual Studio Code Marketplace](https://marketplace.visualstudio.com/) for syntax highlighting and language support.
 
-[![Install on VS Code](https://vsmarketplacebadges.dev/version/salamlanguage.salam-programming-language.svg)](https://marketplace.visualstudio.com/items?itemName=salamlanguage.salam-programming-language)
+[![Install on VS Code](https://vsmarketplacebadges.dev/version/salamlanguage.salam-programming-language.svg?label=Install%20on%20VS%20Code)](https://marketplace.visualstudio.com/items?itemName=salamlanguage.salam-programming-language)
 
 ## 🛠️ The Compiler (`salam`)
 


### PR DESCRIPTION
## Description

Closes #1451 — "Two broken image buttons on the MySTMD docs".

The `https://salamlang.readthedocs.io/latest/` page renders three
`vsmarketplacebadges.dev` badges that look "broken" because the text
inside the SVG (`aria-label` / `<title>`) does not match the alt text
the docs maintainers wrote next to them. Concretely:

| README alt text | Default rendered badge text |
| --- | --- |
| `VS Code Marketplace Version` | `Visual Studio Marketplace: v0.2.3` |
| `VS Code Marketplace Installs` | `Visual Studio Marketplace installs` |
| `Install on VS Code` | `Visual Studio Marketplace: v0.2.3` |

`vsmarketplacebadges.dev` returns a generic-shaped badge whose label
defaults to `Visual Studio Marketplace: <version>`. Without an explicit
`?label=` query parameter, the screenshots show a button that says
"Visual Studio Marketplace: v0.2.3" sitting next to the heading
"Install on VS Code" — looking like a broken image.

## Changes

Adds an explicit `?label=` query parameter to each of the three badges
so the rendered SVG text matches the alt text:

```diff
-[![VS Code Marketplace Version](https://vsmarketplacebadges.dev/version/salamlanguage.salam-programming-language.svg)](https://marketplace.visualstudio.com/items?itemName=salamlanguage.salam-programming-language)
+[![VS Code Marketplace Version](https://vsmarketplacebadges.dev/version/salamlanguage.salam-programming-language.svg?label=VS%20Code%20Marketplace%20Version)](https://marketplace.visualstudio.com/items?itemName=salamlanguage.salam-programming-language)
-[![VS Code Marketplace Installs](https://vsmarketplacebadges.dev/installs/salamlanguage.salam-programming-language.svg)](https://marketplace.visualstudio.com/items?itemName=salamlanguage.salam-programming-language)
+[![VS Code Marketplace Installs](https://vsmarketplacebadges.dev/installs/salamlanguage.salam-programming-language.svg?label=VS%20Code%20Marketplace%20Installs)](https://marketplace.visualstudio.com/items?itemName=salamlanguage.salam-programming-language)
-[![Install on VS Code](https://vsmarketplacebadges.dev/version/salamlanguage.salam-programming-language.svg)](https://marketplace.visualstudio.com/items?itemName=salamlanguage.salam-programming-language)
+[![Install on VS Code](https://vsmarketplacebadges.dev/version/salamlanguage.salam-programming-language.svg?label=Install%20on%20VS%20Code)](https://marketplace.visualstudio.com/items?itemName=salamlanguage.salam-programming-language)
```

After the fix, the badges render as:

- `VS Code Marketplace Version: v0.2.3`
- `VS Code Marketplace Installs: 12`
- `Install on VS Code: v0.2.3`

## Verification

Verified each label renders correctly before sending this PR:

```bash
curl -sL "https://vsmarketplacebadges.dev/version/salamlanguage.salam-programming-language.svg?label=VS%20Code%20Marketplace%20Version" | grep title
# <title>VS Code Marketplace Version: v0.2.3</title>

curl -sL "https://vsmarketplacebadges.dev/installs/salamlanguage.salam-programming-language.svg?label=VS%20Code%20Marketplace%20Installs" | grep title
# <title>VS Code Marketplace Installs: 12</title>

curl -sL "https://vsmarketplacebadges.dev/version/salamlanguage.salam-programming-language.svg?label=Install%20on%20VS%20Code" | grep title
# <title>Install on VS Code: v0.2.3</title>
```

## Notes

- Pure docs change — does not touch the compiler C core.
- No labels were used before, so this is purely additive on the URL.
- The README logo (`<img width="150">` in the title block) and the top
  MySTMD nav buttons (defined in `myst.yml`) both render correctly in
  the current MySTMD build — they were inspected during investigation
  and do not need changes.