### PR TITLE
installer: copy std/ alongside the binary, not just the binary

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -104,6 +104,16 @@ if exist "%EXTRACT_DIR%\salam-%PLATFORM%\tcc" (
   xcopy /e /i /y /q "%EXTRACT_DIR%\salam-%PLATFORM%\tcc" "%INSTALL_DIR%\tcc" >nul
 )
 
+rem The compiler looks for a std\ directory next to its own binary (among
+rem other places); without this, every "import os" fails with "standard
+rem library package not found" once salam.exe is on PATH but std\ was left
+rem behind in the extracted archive.
+if exist "%EXTRACT_DIR%\salam-%PLATFORM%\std" (
+  xcopy /e /i /y /q "%EXTRACT_DIR%\salam-%PLATFORM%\std" "%INSTALL_DIR%\std" >nul
+) else (
+  echo warning: no std\ directory found inside %ASSET% - the compiler will not find the standard library
+)
+
 echo Installed: %INSTALL_DIR%\salam.exe
 "%INSTALL_DIR%\salam.exe" version 2>nul
 

--- a/install.sh
+++ b/install.sh
@@ -212,6 +212,15 @@ fi
 binary="$extract_dir/salam-${platform}/salam"
 [ -f "$binary" ] || binary="$(find "$extract_dir" -type f -name salam | head -n 1)"
 [ -f "$binary" ] || die "could not find 'salam' binary inside $ASSET"
+# RUN-ME.txt inside the archive calls this a "self-contained toolchain" -
+# true when the binary and std/ sit side by side, which is only the case
+# for someone extracting the zip and running ./salam in place. Installing
+# just the binary onto PATH breaks that unless std/ is copied along with
+# it: every "import os" is otherwise a standard-library-not-found error,
+# since the compiler looks for a std/ directory next to its own binary
+# (among other places - see resolve_stdlib_root in the compiler source),
+# and nothing else in this script ever puts one there.
+std_src="$(dirname "$binary")/std"
 
 if [ -z "$INSTALL_DIR" ]; then
     INSTALL_DIR="$HOME/.salam/bin"
@@ -219,6 +228,14 @@ fi
 mkdir -p "$INSTALL_DIR"
 cp "$binary" "$INSTALL_DIR/salam"
 chmod +x "$INSTALL_DIR/salam"
+
+if [ -d "$std_src" ]; then
+    rm -rf "$INSTALL_DIR/std"
+    cp -R "$std_src" "$INSTALL_DIR/std"
+    log "Installed: $INSTALL_DIR/std"
+else
+    log "warning: no std/ directory found inside $ASSET - the compiler will not find the standard library"
+fi
 
 log "Installed: $INSTALL_DIR/salam"
 "$INSTALL_DIR/salam" version >&2 2>/dev/null || true


### PR DESCRIPTION
## Summary
- `install.sh` and `install.bat` extract the release zip and copy out only the `salam`/`salam.exe` binary, discarding the `std/` directory that sits right next to it in the same archive.
- Every release is a "self-contained toolchain" per its own `RUN-ME.txt` - `./salam` works when run straight out of the extracted archive because the binary and `std/` are side by side. Installing via `curl | sh` or `install.bat` breaks that: the compiler's `resolve_stdlib_root()` looks for a `std/` directory next to its own binary (among a few other places), finds nothing, and every single `import` fails with `standard library package 'X' not found`.
- Discovered via a downstream project's CI (BaseMax/salamdns), which had never actually run an installed-from-scratch `salam` on a real GitHub Actions runner until now - `salam version` succeeds (it needs nothing from `std/`), so the break was invisible until the first real `salam build`.
- `install.bat` already had the identical pattern for copying a sibling directory (`tcc/`, for the bundled TCC backend on Windows) right next to where this change adds the same treatment for `std/`. `install.sh` gets the same fix; Linux doesn't bundle `tcc` (CI installs `gcc` separately), so `std/` is the only sibling directory it needs.

## Verification
Since I couldn't run the Linux ELF binary directly, I verified structurally against the real `v0.3.0` linux release asset: downloaded and extracted `salam-0.3.0-linux.zip`, ran the same copy logic the patched `install.sh` runs, and confirmed the resulting layout (`$INSTALL_DIR/salam` + `$INSTALL_DIR/std/`) matches the compiler's own `resolve_stdlib_root()` candidate search (`exe_dir/std`) in `compiler/src/semantic/sema.c`. All the packages the original CI failure named as missing - `std/os`, `std/mem`, `std/testing`, `std/conv`, `std/str` - are present and land in the right place.

- [x] `bash -n install.sh` and `shellcheck -s sh install.sh` clean
- [x] Repo's own pre-commit hooks (including its shellcheck pass) pass on the commit
- [x] Simulated install against the real v0.3.0 linux release asset produces the correct `salam` + `std/` layout

## Test plan
- [ ] A maintainer with a Linux/macOS box: `curl -fsSL https://raw.githubusercontent.com/SalamLang/Salam/refs/heads/<this-branch>/install.sh | sh -s -- --version 0.3.0` then `salam build` something that imports a std package (e.g. `import os`)
- [ ] Same for `install.bat` on Windows