### PR TITLE
release: fix the last Windows gate failure and land the self-hosted mangling port

### DIFF
--- a/compiler/codegen/codegen.salam
+++ b/compiler/codegen/codegen.salam
@@ -156,6 +156,13 @@ pub struct Cg:
     pub locals: Vector<str> = Vector {}
     pub cur_struct: int = 0 // SymId (0 = C NULL)
     pub cur_fn_home: int = 0 // ScopeId (0 = C NULL)
+    // While a struct literal is filling in a field's DEFAULT expression, the
+    // scope that expression was written in - the declaring module's global
+    // scope, which is not this module's when the struct came from a package.
+    // `pub category: int = ERR_EXECUTION` in std/graphql is emitted at every
+    // construction site, so the global it names has to be spelled the way its
+    // own package defines it. Only cg_global_ref reads this.
+    pub cur_lit_home: int = 0 // ScopeId (0 = C NULL)
     pub safe: bool = false
     pub debug_info: bool = false
     pub single_threaded: bool = false

--- a/compiler/codegen/codegen_core.salam
+++ b/compiler/codegen/codegen_core.salam
@@ -99,13 +99,15 @@ func emit_globals(g &: Cg, s &: sm.Sema, a &: at.Ast, program: int):
             continue
         end
         ts := str.Len(d.type_str) > 0 ? d.type_str : "int32_t"
-        decl := cg_decl(ts, d.name)
+        // Package-qualified, so two modules can each declare `COLS`.
+        gname := cg_global_cname(g.pkg, d.name)
+        decl := cg_decl_cn(ts, gname)
         is_array := str.IndexOf(ts, "[") >= 0
         can_defer := d.kind == at.AST_VAR_DECL && d.a != 0 && at.KindOf(a, d.a) != at.AST_LITERAL && !is_array
         if can_defer:
             out(g, decl + ";\n")
             g.deferred.push(
-                cg_cident(d.name) + " = " + cg_expr(g, s, a, d.a) + ";"
+                gname + " = " + cg_expr(g, s, a, d.a) + ";"
             )
         else:
             // Arrays are excluded on purpose. A Salam array parameter is a

--- a/compiler/codegen/codegen_expr.salam
+++ b/compiler/codegen/codegen_expr.salam
@@ -450,7 +450,10 @@ func cg_struct_lit(g &: Cg, s &: sm.Sema, a &: at.Ast, n: int): str:
                 val = cg_expr(g, s, a, at.Get(a, provided).a)
                 has_val = true
             else f.decl != 0 && at.Get(a, f.decl).a != 0:
+                save_lit := g.cur_lit_home
+                g.cur_lit_home = sm.SymAt(s, ssym).home
                 val = cg_expr(g, s, a, at.Get(a, f.decl).a)
+                g.cur_lit_home = save_lit
                 has_val = true
             end
             if !has_val:
@@ -503,6 +506,82 @@ end
 // it is not ours to mangle; without this a libc extern emits a symbol that
 // exists nowhere (`printf` in std/llvm/orc.salam became
 // `_Salam_llvm_printf_str`).
+// The C spelling of a name that is not a local: a module-level global carries
+// its package (cg_global_cname), anything else is the bare identifier. The
+// cur_lit_home / cur_fn_home / cur_struct fallbacks mirror cg_func_addr - a
+// generic body instantiated into another module is emitted with that module's
+// global scope, so its own package's globals are only reachable through its
+// home.
+//
+// An `extern` global keeps its declared C name; it names an object somebody
+// else defined.
+func cg_global_ref(g &: Cg, s &: sm.Sema, a &: at.Ast, name: str): str:
+    mut gsym := sm.Lookup(s, s.global, name)
+    if gsym != 0:
+        gk := sm.SymAt(s, gsym).kind
+        if gk != sm.SYM_VAR && gk != sm.SYM_CONST:
+            gsym = 0
+        end
+    end
+    mut homes := Vector {} as Vector<int>
+    defer homes.free()
+    homes.push(g.cur_lit_home)
+    homes.push(g.cur_fn_home)
+    homes.push(g.cur_struct != 0 ? sm.SymAt(s, g.cur_struct).home : 0)
+    repeat homes.len() with i:
+        if gsym == 0 && homes.get(i) != 0:
+            hs := sm.Lookup(s, homes.get(i), name)
+            if hs != 0 && (sm.SymAt(s, hs).kind == sm.SYM_VAR || sm.SymAt(s, hs).kind == sm.SYM_CONST):
+                gsym = hs
+            end
+        end
+    end
+    if gsym == 0:
+        ret cg_cident(name)
+    end
+    gv := sm.SymAt(s, gsym)
+    if gv.decl != 0 && at.Get(a, gv.decl).is_extern:
+        ret cg_cident(name)
+    end
+    ret cg_global_cname(gv.pkgname, name)
+end
+
+// `pkg.f` as a value: the function lives in the package's member scope, not in
+// this module's global one, and mangles with the package it was declared in
+// rather than the one doing the reading. `pkgid` is the AST_IDENTIFIER naming
+// the package (0 when the reference was unqualified).
+func cg_func_addr_pkg(g &: Cg, s &: sm.Sema, a &: at.Ast, pkgid: int, name: str): str:
+    if pkgid != 0 && at.KindOf(a, pkgid) == at.AST_IDENTIFIER:
+        pname := at.Get(a, pkgid).name
+        mut pk := sm.Lookup(s, s.global, pname)
+        if pk == 0 && g.cur_fn_home != 0:
+            pk = sm.Lookup(s, g.cur_fn_home, pname)
+        end
+        if pk != 0 && sm.SymAt(s, pk).kind == sm.SYM_PACKAGE && sm.SymAt(s, pk).members != 0:
+            m := sm.LookupLocal(s, sm.SymAt(s, pk).members, name)
+            if m != 0 && sm.SymAt(s, m).kind == sm.SYM_FUNC:
+                mv := sm.SymAt(s, m)
+                mut msig := 0
+                if mv.overloads.len() == 1:
+                    msig = mv.overloads.get(0)
+                end
+                if msig != 0 && sm.SigAt(s, msig).decl != 0 && at.Get(a, sm.SigAt(s, msig).decl).is_extern:
+                    ret "((void*)(&" + name + "))"
+                end
+                mpkg := str.Len(mv.pkgname) > 0 ? mv.pkgname : sm.SymAt(s, pk).pkgname
+                if msig != 0:
+                    ret "((void*)(&" + cg_mangle_in(s, mpkg, "", name, sm.SigAt(s, msig).params) + "))"
+                end
+                mut mempty := Vector {} as Vector<int>
+                mraw := cg_mangle_in(s, mpkg, "", name, mempty)
+                mempty.free()
+                ret "((void*)(&" + mraw + "))"
+            end
+        end
+    end
+    ret cg_func_addr(g, s, a, name)
+end
+
 func cg_func_addr(g &: Cg, s &: sm.Sema, a &: at.Ast, name: str): str:
     mut fsym := sm.Lookup(s, s.global, name)
     mut home_pkg := ""
@@ -655,10 +734,10 @@ func cg_expr(g &: Cg, s &: sm.Sema, a &: at.Ast, n: int): str:
                 ret "this->" + cg_cident(nn.name)
             end
         end
-        ret cg_cident(nn.name)
+        ret cg_global_ref(g, s, a, nn.name)
     end
     if k == at.AST_FUNC_ADDR:
-        ret cg_func_addr(g, s, a, nn.name)
+        ret cg_func_addr_pkg(g, s, a, nn.a, nn.name)
     end
     if k == at.AST_THIS:
         ret "this"
@@ -856,6 +935,10 @@ func cg_expr(g &: Cg, s &: sm.Sema, a &: at.Ast, n: int): str:
         ret cg_call(g, s, a, n)
     end
     if k == at.AST_MEMBER:
+        // `pkg.f` read as a value (sema set func_value): its address.
+        if nn.func_value:
+            ret "(int64_t)" + cg_func_addr_pkg(g, s, a, nn.a, nn.name)
+        end
         an2 := at.Get(a, nn.a)
         if nn.a != 0 && an2.kind == at.AST_IDENTIFIER && !local_known(g, an2.name):
             mut e := sm.Lookup(s, s.global, an2.name)

--- a/compiler/codegen/codegen_header.salam
+++ b/compiler/codegen/codegen_header.salam
@@ -1113,7 +1113,8 @@ func hdr_globals(g &: Cg, a &: at.Ast, program: int):
             continue
         end
         ts := str.Len(d.type_str) > 0 ? d.type_str : "int32_t"
-        decl := cg_decl(ts, d.name)
+        // Must match emit_globals' spelling exactly (cg_global_cname).
+        decl := cg_decl_cn(ts, cg_global_cname(g.pkg, d.name))
         is_array := str.IndexOf(ts, "[") >= 0
         can_defer := d.kind == at.AST_VAR_DECL && d.a != 0 && at.KindOf(a, d.a) != at.AST_LITERAL && !is_array
         // !is_array matches emit_globals in codegen_core - see the comment

--- a/compiler/codegen/codegen_type.salam
+++ b/compiler/codegen/codegen_type.salam
@@ -535,12 +535,35 @@ func cg_array_ctype(ts: str): str:
     ret r
 end
 
+// The C name of a module-level global. Functions and types have carried their
+// package since the beginning; globals went out under their bare Salam name,
+// so two modules that each declared `const COLS` produced two `COLS` objects
+// in one flat C namespace and the link failed with "multiple definition" -
+// even when neither was `pub`, and even for std's own `excel.FormatUnknown`
+// against `image.FormatUnknown`, which is why no program could import both.
+//
+// `pkg` is the package the global was declared in, not necessarily the module
+// being emitted: a generic body instantiated in another module still reads
+// its home package's globals, and must name them the same way that package
+// defined them.
+func cg_global_cname(pkg: str, name: str): str:
+    ret "_Salam_g_" + cg_cident(str.Len(pkg) > 0 ? pkg : "main") + "_" + cg_cident(name)
+end
+
 func cg_decl(ts: str, name: str): str:
+    ret cg_decl_cn(ts, cg_cident(name))
+end
+
+// cg_decl over a name that is already a C identifier. A module-level global is
+// spelled with its package baked in (cg_global_cname), and that spelling must
+// not go through cg_cident a second time - the encoder doubles interior
+// underscores, so the definition and the extern would disagree.
+func cg_decl_cn(ts: str, name: str): str:
     if cg_is_slice_ts(ts):
-        ret "salam_slice " + cg_cident(name)
+        ret "salam_slice " + name
     end
     if str.StartsWith(ts, "Variant<"):
-        ret cg_variant_cname(ts) + " " + cg_cident(name)
+        ret cg_variant_cname(ts) + " " + name
     end
     if str.StartsWith(ts, "dyn "):
         suf := pbrk_arr_star(ts, 4)
@@ -557,10 +580,10 @@ func cg_decl(ts: str, name: str): str:
         if suf >= 0 && byte_at(ts, suf) == 91:
             dstr = str.Substr(ts, suf, str.Len(ts) - suf)
         end
-        ret "_Salam_dyn_" + cg_cident(iface) + star + " " + cg_cident(name) + dstr
+        ret "_Salam_dyn_" + cg_cident(iface) + star + " " + name + dstr
     end
     if str.StartsWith(ts, "func(") || str.StartsWith(ts, "externfunc("):
-        ret "void* " + cg_cident(name)
+        ret "void* " + name
     end
     mut base := ""
     mut ptr := false
@@ -578,7 +601,7 @@ func cg_decl(ts: str, name: str): str:
         bc = bc + "*"
         eptr -= 1
     end
-    cname := cg_cident(name)
+    cname := name
     if dims.len() > 0:
         mut b := co.SbNew()
         co.SbPuts(b, bc)

--- a/compiler/llvmgen/llvm_call.salam
+++ b/compiler/llvmgen/llvm_call.salam
@@ -446,7 +446,7 @@ func pkg_value(
         ret false
     end
     touch_pkg_named(v, s, a, py.pkgname)
-    gi := global_find(v, nn.name)
+    gi := global_find_in(v, py.pkgname, nn.name)
     if gi < 0:
         ret false
     end

--- a/compiler/llvmgen/llvm_call_kinds.salam
+++ b/compiler/llvmgen/llvm_call_kinds.salam
@@ -315,7 +315,7 @@ func call_method(v &: Lv, s &: sm.Sema, a &: at.Ast, n: int, callee: int): Llv:
             osc = v.pkg_scope
         end
         ensure_fn(v, s, a, sm.SigAt(s, sig).decl, ss, osc)
-        mut owner_nm := sm.SymAt(s, ss).name
+        mut owner_nm := owner_key(s, ss)
         if str.Len(owner_nm) == 0:
             owner_nm = sname2
         end

--- a/compiler/llvmgen/llvm_decl.salam
+++ b/compiler/llvmgen/llvm_decl.salam
@@ -122,6 +122,35 @@ func mangle(v &: Lv, s &: sm.Sema, owner: str, fn_name: str, sig: int): str:
     ret mangle_in(v, s, pkg_of_scope(s, v.pkg_scope), owner, fn_name, sig)
 end
 
+// A method's owner, spelled the one way every side of the call agrees on.
+//
+// It used to be the struct's DECLARED name, so `pa.Input.free` and
+// `pb.Input.free` both mangled to @salam_Input_free: one body was emitted and
+// every call to either bound to it. The bodies read `this` at their own
+// struct's field offsets, so a call that got the wrong one loaded whatever
+// happened to sit at that offset in the other layout - which is how a
+// `Vector<i64>` receiver came out eight bytes past its real address and free()
+// was handed the {count, cap} pair as if it were the data pointer. The C
+// backend never had this: cg_mangle_method has always folded the owner's
+// package into the name.
+//
+// The canonical type name is unique by construction and is exactly what a
+// receiver's type_str already carries, so call sites can derive it without
+// knowing anything the declared name did not already tell them.
+func owner_key(s &: sm.Sema, osym: int): str:
+    if osym == 0:
+        ret ""
+    end
+    ov := sm.SymAt(s, osym)
+    if ov.ty != sm.TYPE_NONE:
+        ts := sm.ToString(s, ov.ty)
+        if str.Len(ts) > 0:
+            ret ts
+        end
+    end
+    ret ov.name
+end
+
 // ll_pick_overload - first exact arg-typestring match; else first
 // arity-compatible; else overload 0.
 func pick_overload(
@@ -317,7 +346,7 @@ func emit_function(v &: Lv, s &: sm.Sema, a &: at.Ast, fn: int, owner: int):
         fname = fnode.name
     else:
         fname = mangle(
-            v, s, owner != 0 ? sm.SymAt(s, owner).name : "", fnode.name, sig
+            v, s, owner != 0 ? owner_key(s, owner) : "", fnode.name, sig
         )
     end
     mut recv_param := ""
@@ -549,7 +578,7 @@ func ensure_vtbl(
                 ensure_fn(v, s, a, sm.SigAt(s, csig).decl, csym, v.pkg_scope)
                 co.SbPuts(
                     slots, "ptr @" + mangle(
-                        v, s, concrete, im.name, csig
+                        v, s, owner_key(s, csym), im.name, csig
                     )
                 )
             else:

--- a/compiler/llvmgen/llvm_emit.salam
+++ b/compiler/llvmgen/llvm_emit.salam
@@ -215,3 +215,20 @@ func global_find(v &: Lv, name: str): int:
     end
     ret 0 - 1
 end
+
+// global_find restricted to the package that declared the global. An empty
+// `pkg` on either side matches anything, which is what keeps extern globals
+// (shared by the whole program) reachable.
+func global_find_in(v &: Lv, pkg: str, name: str): int:
+    repeat v.globals.len() with i:
+        gv := v.globals.get(i)
+        if !str.Equals(gv.name, name):
+            continue
+        end
+        if str.Len(pkg) > 0 && str.Len(gv.pkg) > 0 && !str.Equals(pkg, gv.pkg):
+            continue
+        end
+        ret i
+    end
+    ret 0 - 1
+end

--- a/compiler/llvmgen/llvm_expr.salam
+++ b/compiler/llvmgen/llvm_expr.salam
@@ -260,13 +260,13 @@ func op_struct(v &: Lv, s &: sm.Sema, a &: at.Ast, ts: str, sname2 &: str): int:
     end
     sname2 = is_ptr_ts(ts) ? str.Substr(ts, 0, str.Len(ts) - 1) : ts
     ss := struct_sym(v, s, a, sname2)
-    // Mangle by the struct symbol's own name, never by the spelling at the
-    // use site. ensure_fn emits the body through lv_function(.., ss), which
-    // mangles with the symbol's name, so a receiver whose type_str carries
-    // the package ("excel.FileMeta") would call @salam_excel__FileMeta_free
-    // while the definition landed as @salam_FileMeta_free.
+    // Mangle by the struct symbol's canonical type name, never by the spelling
+    // at the use site: ensure_fn emits the body through lv_function(.., ss),
+    // which uses owner_key, and the two have to agree. Resolving the symbol
+    // first also normalises a receiver whose type_str was written some other
+    // way.
     if ss != 0:
-        nm := sm.SymAt(s, ss).name
+        nm := owner_key(s, ss)
         if str.Len(nm) > 0:
             sname2 = nm
         end

--- a/compiler/llvmgen/llvm_globals.salam
+++ b/compiler/llvmgen/llvm_globals.salam
@@ -336,6 +336,16 @@ end
 // ll_emit_globals
 func emit_globals(v &: Lv, s &: sm.Sema, a &: at.Ast, program: int):
     mut any := false
+    // Every global carries the package it was declared in. The LLVM backend
+    // puts the whole program in one module, so without that the second package
+    // to declare a `COLS` was skipped as "already emitted" and both packages
+    // then read the first one's storage - the same collision the C backend
+    // reported as a duplicate definition at link time, except here it linked
+    // and quietly returned the wrong value.
+    mut gpkg := pkg_of_scope(s, v.pkg_scope)
+    if str.Len(gpkg) == 0:
+        gpkg = "main"
+    end
     mut i := 0
     until i < at.ChildCount(a, program):
         d := at.Child(a, program, i)
@@ -345,7 +355,7 @@ func emit_globals(v &: Lv, s &: sm.Sema, a &: at.Ast, program: int):
         // duplicate definition in the module. This lets the function be
         // called again for a package whose globals may or may not have been
         // emitted already, which lv_addr_of relies on.
-        if !skip && global_find(v, dn.name) >= 0:
+        if !skip && global_find_in(v, gpkg, dn.name) >= 0:
             skip = true
         end
         // An extern *variable* - POSIX `environ`, which std/os/process
@@ -362,29 +372,38 @@ func emit_globals(v &: Lv, s &: sm.Sema, a &: at.Ast, program: int):
             ev.name = dn.name
             ev.ptr = eref
             ev.ts = ets
+            // No package: it is the one object everyone links against.
+            ev.pkg = ""
+            ev.init = 0
             v.globals.push(ev)
             any = true
             skip = true
         end
         if !skip:
             ts := str.Len(dn.type_str) > 0 ? dn.type_str : "i32"
-            gref := "@g." + str.TrimPrefix(struct_ltype(dn.name), "%struct.")
+            gref := "@g." + gpkg + "." + str.TrimPrefix(struct_ltype(dn.name), "%struct.")
             lty := ty_of(v, s, a, ts)
             mut init := ""
             mut cv := ""
+            mut gv := LvVar {}
+            gv.name = dn.name
+            gv.ptr = gref
+            gv.ts = ts
+            gv.pkg = gpkg
+            gv.init = 0
             if dn.a != 0 && const_value(v, s, a, dn.a, cv):
                 init = cv
             else:
                 init = zero_of(s, ts)
                 if dn.a != 0:
-                    v.gdefer.push(d)
+                    gv.init = dn.a
+                    // The index of the entry pushed just below, not a name to
+                    // look back up: two packages can have a global of the same
+                    // name and the lookup would pick one of them at random.
+                    v.gdefer.push(v.globals.len())
                 end
             end
             out_g(v, gref + " = internal global " + lty + " " + init + "\n")
-            mut gv := LvVar {}
-            gv.name = dn.name
-            gv.ptr = gref
-            gv.ts = ts
             v.globals.push(gv)
             any = true
         end
@@ -598,15 +617,15 @@ end
 // ll_emit_global_inits - runs at the top of main().
 func emit_global_inits(v &: Lv, s &: sm.Sema, a &: at.Ast):
     repeat v.gdefer.len() with i:
-        d := v.gdefer.get(i)
-        dn := at.Get(a, d)
-        gi := global_find(v, dn.name)
-        if gi >= 0:
+        gi := v.gdefer.get(i)
+        if gi >= 0 && gi < v.globals.len():
             g := v.globals.get(gi)
-            val := conv(v, s, a, lv_expr(v, s, a, dn.a), g.ts)
-            emit(
-                v, "store " + ty_of(v, s, a, g.ts) + " " + val + ", ptr " + g.ptr
-            )
+            if g.init != 0:
+                val := conv(v, s, a, lv_expr(v, s, a, g.init), g.ts)
+                emit(
+                    v, "store " + ty_of(v, s, a, g.ts) + " " + val + ", ptr " + g.ptr
+                )
+            end
         end
     end
 end

--- a/compiler/llvmgen/llvm_member.salam
+++ b/compiler/llvmgen/llvm_member.salam
@@ -54,7 +54,15 @@ func lv_addr_of(v &: Lv, s &: sm.Sema, a &: at.Ast, n: int): LvAddr:
                 ret ra2
             end
         end
-        gi := global_find(v, nm)
+        // The enclosing function's own package first. An unqualified name can
+        // only mean this package's global (or an extern, which carries no
+        // package), so a same-named global in some other package must not win
+        // the lookup just by having been emitted earlier.
+        mut curpkg := pkg_of_scope(s, v.pkg_scope)
+        if str.Len(curpkg) == 0:
+            curpkg = "main"
+        end
+        gi := global_find_in(v, curpkg, nm)
         if gi >= 0:
             gv := v.globals.get(gi)
             mut ra3 := LvAddr {}
@@ -87,7 +95,7 @@ func lv_addr_of(v &: Lv, s &: sm.Sema, a &: at.Ast, n: int): LvAddr:
                 continue
             end
             touch_pkg(v, s, a, tpk)
-            tgf := global_find(v, nm)
+            tgf := global_find_in(v, sm.SymAt(s, tpk).pkgname, nm)
             if tgf >= 0:
                 tgvar := v.globals.get(tgf)
                 mut ra5 := LvAddr {}
@@ -115,8 +123,11 @@ func lv_addr_of(v &: Lv, s &: sm.Sema, a &: at.Ast, n: int): LvAddr:
             if pgk != 0:
                 pgy := sm.SymAt(s, pgk)
                 if pgy.kind == sm.SYM_PACKAGE && pgy.decl != 0:
+                    saved_ps := v.pkg_scope
+                    v.pkg_scope = pgy.members
                     emit_globals(v, s, a, pgy.decl)
-                    pgf := global_find(v, nm)
+                    v.pkg_scope = saved_ps
+                    pgf := global_find_in(v, pgy.pkgname, nm)
                     if pgf >= 0:
                         pgv := v.globals.get(pgf)
                         mut ra6 := LvAddr {}
@@ -127,6 +138,15 @@ func lv_addr_of(v &: Lv, s &: sm.Sema, a &: at.Ast, n: int): LvAddr:
                 end
             end
             pgi += 1
+        end
+        // Last chance: an extern global, which belongs to no package.
+        xgi := global_find(v, nm)
+        if xgi >= 0:
+            xgv := v.globals.get(xgi)
+            mut ra7 := LvAddr {}
+            ra7.ptr = xgv.ptr
+            ra7.ts = xgv.ts
+            ret ra7
         end
         lv_error(v, a, n, "address of an unknown identifier '" + nm + "'")
         mut ra4 := LvAddr {}
@@ -774,6 +794,30 @@ end
 // form exists - and skipping it here left `@salam_com_addref` with neither a
 // declare nor a define anywhere in the module ("use of undefined value").
 func lv_func_symbol(v &: Lv, s &: sm.Sema, a &: at.Ast, n: int, name: str): str:
+    // `pkg.f` as a value: the function is in the package's member scope and
+    // mangles with the package that declared it, not the reading one.
+    pkgid := at.Get(a, n).a
+    if pkgid != 0 && at.KindOf(a, pkgid) == at.AST_IDENTIFIER:
+        pk := sym_of(v, s, a, at.Get(a, pkgid).name)
+        if pk != 0 && sm.SymAt(s, pk).kind == sm.SYM_PACKAGE && sm.SymAt(s, pk).members != 0:
+            m := sm.LookupLocal(s, sm.SymAt(s, pk).members, name)
+            if m != 0 && sm.SymAt(s, m).kind == sm.SYM_FUNC && sm.SymAt(s, m).overloads.len() == 1:
+                msig := sm.SymAt(s, m).overloads.get(0)
+                if msig != 0 && sm.SigAt(s, msig).decl != 0:
+                    saved := v.pkg_scope
+                    touch_pkg(v, s, a, pk)
+                    v.pkg_scope = sm.SymAt(s, pk).members
+                    ensure_fn(v, s, a, sm.SigAt(s, msig).decl, 0, sm.SymAt(s, pk).members)
+                    mut msym := name
+                    if !at.Get(a, sm.SigAt(s, msig).decl).is_extern:
+                        msym = mangle(v, s, "", name, msig)
+                    end
+                    v.pkg_scope = saved
+                    ret msym
+                end
+            end
+        end
+    end
     fsym := sym_of(v, s, a, name)
     if fsym == 0 || sm.SymAt(s, fsym).kind != sm.SYM_FUNC || sm.SymAt(s, fsym).overloads.len() != 1:
         lv_error(v, a, n, "cannot take the address of '" + name + "'")
@@ -910,6 +954,16 @@ func lv_expr(v &: Lv, s &: sm.Sema, a &: at.Ast, n: int): Llv:
         ret lv_call(v, s, a, n)
     end
     if k == at.AST_MEMBER:
+        // `pkg.f` read as a value (sema set func_value): its address, i64.
+        if node.func_value:
+            mfsym := lv_func_symbol(v, s, a, n, node.name)
+            if str.Len(mfsym) == 0:
+                ret poison("i64")
+            end
+            rmf := new_tmp(v)
+            emit(v, rmf + " = ptrtoint ptr @" + mfsym + " to i64")
+            ret make_llv(rmf, "i64")
+        end
         if node.a != 0 && at.KindOf(a, node.a) == at.AST_IDENTIFIER:
             e := enum_sym(v, s, a, at.Get(a, node.a).name)
             if e != 0:

--- a/compiler/llvmgen/llvmgen.salam
+++ b/compiler/llvmgen/llvmgen.salam
@@ -281,6 +281,14 @@ pub struct LvVar:
     pub name: str = ""
     pub ptr: str = ""
     pub ts: str = ""
+    // Set on module-level globals: the package that declared this one, so two
+    // packages can each have a `COLS` without the second silently binding to
+    // the first's storage. "" on function locals and on extern globals, which
+    // name one object the whole program shares.
+    pub pkg: str = ""
+    // A module-level global whose initialiser is not an LLVM constant: the
+    // expression node, replayed by emit_global_inits.
+    pub init: int = 0
 end
 
 // lstr_t - an interned string constant.
@@ -320,7 +328,7 @@ pub struct Lv:
     pub this_ref: str = ""
     pub self_byval: bool = false
     pub globals: Vector<LvVar> = Vector {}
-    pub gdefer: Vector<int> = Vector {} // at.NodeIds of runtime-init decls
+    pub gdefer: Vector<int> = Vector {} // indices into `globals`
     pub extern_names: Vector<str> = Vector {}
     pub pkg_scope: int = 0 // sm ScopeId (0 = C NULL)
     pub emitted: Vector<str> = Vector {}

--- a/compiler/parser/parser_expr_primary.salam
+++ b/compiler/parser/parser_expr_primary.salam
@@ -122,6 +122,20 @@ func parse_primary(p &: Ps, a &: at.Ast): int:
         n := p_mk(p, a, at.AST_FUNC_ADDR)
         p_advance(p)
         at.SetName(a, n, p_name(p, "expected a function name after '&'"))
+        // `&pkg.f`. Without this the '&' bound to the package identifier alone
+        // and the '.f' became a member access on it, which reported
+        // "'&pkg' requires a function". The package goes in `n.a`, the same
+        // shape a member access has, so the backends resolve both alike.
+        if p_at(p, tok.TK_DOT) && p_peek2(p).kind == tok.TK_IDENT:
+            pkg := p_mk(p, a, at.AST_IDENTIFIER)
+            at.SetName(a, pkg, at.Get(a, n).name)
+            p_fin(p, a, pkg)
+            p_advance(p)
+            at.SetName(a, n, p_name(p, "expected a function name after '&'"))
+            mut nv2 := at.Get(a, n)
+            nv2.a = pkg
+            at.Put(a, n, nv2)
+        end
         p_fin(p, a, n)
         ret n
     end

--- a/compiler/semantic/sema_check_core.salam
+++ b/compiler/semantic/sema_check_core.salam
@@ -209,6 +209,54 @@ func sema_check_expr(s &: Sema, a &: at.Ast, nid: int): int:
         if at.NameIsErr(fname):
             ret sema_decorate(s, a, nid, sema_err_ty(s))
         end
+        // `&pkg.f` - the package identifier the parser parked in n.a.
+        pkgid := at.Get(a, nid).a
+        if pkgid != 0 && at.KindOf(a, pkgid) == at.AST_IDENTIFIER:
+            pname := at.Get(a, pkgid).name
+            pk := scope_lookup(s, s.cur, pname)
+            if pk == 0 || sym_at(s, pk).kind != SYM_PACKAGE:
+                serr(
+                    s, 1, sp, co.Format3(
+                        i18.Tr("unknown package '%s' in '&%s.%s'"), co.ArgStr(pname),
+                        co.ArgStr(pname), co.ArgStr(fname)
+                    )
+                )
+                ret sema_decorate(s, a, nid, sema_err_ty(s))
+            end
+            pkv2 := sym_at(s, pk)
+            fname = pkg_member_canon(s, a, pk, fname, sp)
+            at.SetName(a, nid, fname)
+            m3 := scope_lookup_local(s, pkv2.members, fname)
+            if m3 == 0 || sym_at(s, m3).kind != SYM_FUNC:
+                serr(
+                    s, 72, sp, co.Format2(
+                        i18.Tr("'&%s.%s' requires a function"), co.ArgStr(pkv2.name), co.ArgStr(fname)
+                    )
+                )
+                ret sema_decorate(s, a, nid, sema_err_ty(s))
+            end
+            mv3 := sym_at(s, m3)
+            if !mv3.is_pub:
+                serr(
+                    s, 17, sp, co.Format2(
+                        i18.Tr("'%s' is not exported by package '%s' (mark it 'pub')"), co.ArgStr(fname),
+                        co.ArgStr(pkv2.name)
+                    )
+                )
+                ret sema_decorate(s, a, nid, sema_err_ty(s))
+            end
+            if !func_addr_target_ok(s, a, m3, fname, sp):
+                ret sema_decorate(s, a, nid, sema_err_ty(s))
+            end
+            mut mv3u := sym_at(s, m3)
+            mv3u.used = true
+            sym_put(s, m3, mv3u)
+            dce_mark_root(
+                str.Len(mv3u.pkgname) > 0 ? mv3u.pkgname : pkv2.name, mv3u.name
+            )
+            _dpa := sema_decorate(s, a, pkgid, pkv2.ty)
+            ret sema_decorate(s, a, nid, type_ptr(s, sema_ty(s, TY_VOID)))
+        end
         mut fsym := scope_lookup(s, s.cur, fname)
         if fsym == 0:
             c2 := local_canon(s, a, fname, sp)

--- a/compiler/semantic/sema_decl.salam
+++ b/compiler/semantic/sema_decl.salam
@@ -565,6 +565,12 @@ func sema_collect(s &: Sema, a &: at.Ast, program: int):
             gv.is_mut = d.is_mut
             gv.is_pub = d.is_pub
             gv.decl = did
+            // codegen spells a module-level global with its package baked in,
+            // so it has to know which package that was - a generic body
+            // emitted into another module reads globals through its home
+            // scope, not the module being compiled.
+            gv.pkgname = s.pkg
+            gv.home = s.global
             if d.kind == at.AST_CONST_DECL && d.a != 0:
                 da := at.Get(a, d.a)
                 if da.kind == at.AST_LITERAL && da.value_kind == tok.TV_INT:

--- a/compiler/semantic/sema_expr.salam
+++ b/compiler/semantic/sema_expr.salam
@@ -444,12 +444,25 @@ func check_member(s &: Sema, a &: at.Ast, nid: int): int:
                 ret sema_decorate(s, a, nid, sema_err_ty(s))
             end
             if mv.kind == SYM_FUNC:
-                serr(
-                    s, 17, sp, co.Format2(
-                        i18.Tr("function '%s.%s' used as a value (call it)"), co.ArgStr(pkv.name), co.ArgStr(mname)
-                    )
+                // `pkg.f` read as a value decays to its address, typed i64 -
+                // exactly what a bare `f` in the current package does. It used
+                // to be rejected outright, so every function a router or any
+                // other handler table points at had to live in the same file
+                // as the table.
+                if !func_addr_target_ok(s, a, m, mname, sp):
+                    ret sema_decorate(s, a, nid, sema_err_ty(s))
+                end
+                mut mvu := sym_at(s, m)
+                mvu.used = true
+                sym_put(s, m, mvu)
+                dce_mark_root(
+                    str.Len(mvu.pkgname) > 0 ? mvu.pkgname : pkv.name, mvu.name
                 )
-                ret sema_decorate(s, a, nid, sema_err_ty(s))
+                _dp := sema_decorate(s, a, n.a, pkv.ty)
+                mut fvn2 := at.Get(a, nid)
+                fvn2.func_value = true
+                at.Put(a, nid, fvn2)
+                ret sema_decorate(s, a, nid, sema_ty(s, TY_I64))
             end
             // `pkg.EnumName` or `pkg.StructName` alone: a bare reference to
             // the type itself, not a value - the same rule the unqualified

--- a/compiler/semantic/sema_lit.salam
+++ b/compiler/semantic/sema_lit.salam
@@ -142,7 +142,18 @@ func resolve_pkg_struct_lit(s &: Sema, a &: at.Ast, nid: int, name: str, dot: in
         )
         ret 0
     end
-    at.SetName(a, nid, tname)
+    // The canonical "pkg_Name", not the bare "Name". Every backend resolves a
+    // struct literal by the name left here, and a bare name is resolved by
+    // first match: with `alpha.Input` and `beta.Input` both imported, a
+    // `beta.Input { b = "y" }` bound to alpha's struct, took alpha's field
+    // defaults, and silently dropped `b = "y"` because alpha has no such
+    // field. It only surfaced as a C error because the two shapes happened to
+    // be incompatible; where they agree, it compiled and produced wrong data.
+    mut canon := tname
+    if tsv.ty != TYPE_NONE && str.Len(ty_at(s, tsv.ty).name) > 0:
+        canon = ty_at(s, tsv.ty).name
+    end
+    at.SetName(a, nid, canon)
     ret tsym
 end
 

--- a/compiler/tests_port/codegen_test.salam
+++ b/compiler/tests_port/codegen_test.salam
@@ -490,7 +490,7 @@ func test_module_output():
     testing.AssertContains(
         c, "const int32_t _r = puts(_Salam_main_helper_str(\"hi\"));\n"
     )
-    testing.AssertContains(h, "extern const int32_t MAXN;\n")
+    testing.AssertContains(h, "extern const int32_t _Salam_g_main_MAXN;\n")
     testing.AssertContains(
         h, "double _Salam_main_S_Point_dist(Point* this);\n"
     )
@@ -522,8 +522,8 @@ func test_module_output():
         c, "static const char* _Salam_main_helper_str(const char* s);\n"
     )
     // global initializers, real cg_expr text now that 6b is ported.
-    testing.AssertContains(c, "const int32_t MAXN = 100;\n")
-    testing.AssertContains(c, "int32_t g__count = 7;\n")
+    testing.AssertContains(c, "const int32_t _Salam_g_main_MAXN = 100;\n")
+    testing.AssertContains(c, "int32_t _Salam_g_main_g__count = 7;\n")
     testing.AssertContains(c, "int main(int argc, char** argv) {\n")
     testing.AssertContains(c, "    salam_set_args(argc, argv);\n")
     testing.AssertContains(c, "    return 0;\n")
@@ -561,12 +561,12 @@ func test_pkg_module_output():
     end
     // type alias + pkg globals (every pkg global is extern'd in the .h).
     testing.AssertContains(h, "typedef int32_t Id2;\n")
-    testing.AssertContains(h, "extern int32_t g__u2;\n")
+    testing.AssertContains(h, "extern int32_t _Salam_g_util2_g__u2;\n")
     // THE extern-const array bug (PORTING.md), ported bug-for-bug: the .h
     // declares the non-mut array const, the .c defines it non-const.
-    testing.AssertContains(h, "extern int32_t vals[2];\n")
-    testing.AssertContains(c, "\nint32_t vals[2] = ")
-    testing.AssertFalse(str.Contains(c, "const int32_t vals[2]"))
+    testing.AssertContains(h, "extern int32_t _Salam_g_util2_vals[2];\n")
+    testing.AssertContains(c, "\nint32_t _Salam_g_util2_vals[2] = ")
+    testing.AssertFalse(str.Contains(c, "const int32_t _Salam_g_util2_vals[2]"))
     // sret: by-value struct returns become a trailing __ret out-param.
     testing.AssertContains(
         h, "void _Salam_util2_MkPair2_i32_i32(int32_t x, int32_t y, " + "util2__Pair2* __ret);\n"

--- a/docs/ai/stdlib-index.json
+++ b/docs/ai/stdlib-index.json
@@ -3421,6 +3421,7 @@
       "pub func EncodeQuery(name: str, qtype: int, id: int): compress.ByteBuf:",
       "pub func EncodeTableSizeUpdate(out &: compress.ByteBuf, t &: DynTable, new_size: int):",
       "pub func End(h: i64):",
+      "pub func Error(r: Response): str:",
       "pub func ErrorCodeOf(f: Frame): int:",
       "pub func ErrorName(code: int): str:",
       "pub func ExpiredCookie(name: str, path: str, domain: str): Cookie:",

--- a/std/net/http/http.salam
+++ b/std/net/http/http.salam
@@ -63,6 +63,10 @@ end
 
 mut _g_http_status := 0
 mut _g_http_headers := ""
+// Why the last request produced no response, when it produced none. A failed
+// TLS handshake and a server that answered with nothing both left status 0 and
+// an empty body, with no way for a caller to tell them apart.
+mut _g_http_error := ""
 
 @en "Response"
 @fa "پاسخ"
@@ -71,6 +75,10 @@ pub struct Response:
     pub status: int = 0
     pub body: str = ""
     pub head: str = ""
+    // Empty on any response that came back from the server, including a 500.
+    // Non-empty only when the request never got one: DNS, connect, or - most
+    // often - the TLS handshake. See Error().
+    pub err: str = ""
 end
 
 @en "Client"
@@ -566,6 +574,7 @@ else:
             end
         end
         if u.host.len() == 0:
+            _g_http_error = "no host in URL '" + url_str + "'"
             ret ""
         end
         req := _build_request(method, u, headers, body)
@@ -575,6 +584,7 @@ else:
             cfg := tls.NewConfig(u.host)
             mut c := tls.Dial(u.host, port, cfg)
             if !tls.ConnOk(c):
+                _g_http_error = "TLS: " + tls.ConnError(c)
                 tls.Close(c)
                 ret ""
             end
@@ -584,6 +594,7 @@ else:
         else:
             s := rawsock.Connect(u.host, port)
             if !rawsock.Ok(s):
+                _g_http_error = "could not connect to " + u.host + ":" + port
                 ret ""
             end
             rawsock.Send(s, req)
@@ -627,10 +638,10 @@ func _parse_response(req: str): Response:
     sep_pos := req.find("\r\n\r\n")
     if sep_pos >= 0:
         _g_http_headers = req.substr(0, sep_pos + 4)
-        ret Response { status = _g_http_status, body = req.substr(sep_pos + 4, req.len() - sep_pos - 4), head = _g_http_headers }
+        ret Response { status = _g_http_status, body = req.substr(sep_pos + 4, req.len() - sep_pos - 4), head = _g_http_headers, err = _g_http_error }
     end
     _g_http_headers = ""
-    ret Response { status = _g_http_status, body = req, head = "" }
+    ret Response { status = _g_http_status, body = req, head = "", err = _g_http_error }
 end
 
 func serialize(headers: HashMap<str, str>): str:
@@ -646,6 +657,7 @@ end
 func send(method: str, url_str: str, header_block: str, body: str): Response:
     _g_http_status = 0
     _g_http_headers = ""
+    _g_http_error = ""
     mut effective_headers := header_block
     if body.len() > 0:
         if header_block.find("Content-Type") < 0:
@@ -724,6 +736,16 @@ end
 @ar "متن"
 pub func Body(r: Response): str:
     ret r.body
+end
+
+@en "Error"
+@fa "خطا"
+@ar "خطأ"
+// Why no response arrived, or "" when one did. `Status(r) == 0` on its own
+// cannot tell a refused connection or a failed TLS handshake from a server
+// that closed without writing a status line; this can.
+pub func Error(r: Response): str:
+    ret r.err
 end
 
 @en "Headers"

--- a/std/term/term.salam
+++ b/std/term/term.salam
@@ -512,7 +512,20 @@ pub func EnableAnsi(): bool:
     if SALAM_OS_WINDOWS:
         h := _win_handle(StdoutFd)
         if h == null: ret false end
-        ret SetConsoleMode(h, _win_mode(StdoutFd) | 0x4) != 0
+        buf := mem.Allocate(8 as u64)
+        defer mem.Free(buf)
+        memset(buf, 0, 8 as u64)
+        // GetConsoleMode only succeeds on a real console handle. When it
+        // fails, stdout is a pipe or a file: there is no console mode to
+        // switch, and the escape bytes reach the other end untouched -
+        // exactly what happens on POSIX, which reports true for the same
+        // redirected stream. Report true too, so the answer does not depend
+        // on the platform for a case neither platform has to do anything
+        // about. A false here means the opposite: this IS a console and
+        // virtual-terminal processing could not be turned on.
+        if GetConsoleMode(h, buf) == 0: ret true end
+        p := buf as int*
+        ret SetConsoleMode(h, p[0] | 0x4) != 0
     else:
         ret true
     end

--- a/std/tls/tls12.salam
+++ b/std/tls/tls12.salam
@@ -131,6 +131,37 @@ end
 //
 // The signature covers client_random || server_random || the ECDHParams above,
 // which is why those bytes are captured verbatim rather than re-encoded.
+// A fresh ECDHE keypair on `cv`, replacing whatever the ClientHello
+// pre-generated. The scalar has to be a valid private key - non-zero and below
+// the group order - which a random draw misses only with negligible
+// probability, so a few retries is a complete answer rather than a loop that
+// can spin.
+func _tls12_gen_ec_key(h &: Handshake, cv: Curve): bool:
+    mut x := _newbuf(cv.nb)
+    defer _buf_free(x)
+    mut y := _newbuf(cv.nb)
+    defer _buf_free(y)
+    mut tries := 0
+    until tries < 8:
+        tries += 1
+        _bufreset(x)
+        _bufreset(y)
+        _putzeros(x, cv.nb)
+        _putzeros(y, cv.nb)
+        _bufreset(h.ecpriv)
+        _putzeros(h.ecpriv, cv.nb)
+        crypto.RandomBytes(h.ecpriv.p, cv.nb)
+        if _ec_base_mul(cv, h.ecpriv.p, x.p, y.p):
+            _bufreset(h.ecpub)
+            _put8(h.ecpub, 4)
+            _putbuf(h.ecpub, x)
+            _putbuf(h.ecpub, y)
+            ret !h.ecpub.bad && !h.ecpriv.bad
+        end
+    end
+    ret false
+end
+
 func _tls12_parse_ske(h &: Handshake, msg: Reader): bool:
     mut r := msg
     ctype := _rd8(r)
@@ -192,6 +223,17 @@ func _tls12_parse_ske(h &: Handshake, msg: Reader): bool:
         mut cv := _curve_p256()
         if group == GROUP_SECP384R1:
             cv = _curve_p384()
+        end
+        // The ClientHello can only pre-generate one EC keypair, and it picks
+        // P-256; a server that answers on P-384 needs a P-384 one. Reusing the
+        // P-256 pair read a 48-byte scalar out of a 32-byte buffer and then
+        // sent a 65-byte P-256 point as the ClientKeyExchange, so our shared
+        // secret and the point we published described different keys. The
+        // server's first look at that was our Finished, which it rejected by
+        // dropping the connection - a "connection closed during handshake"
+        // against every host that prefers secp384r1.
+        if !_tls12_gen_ec_key(h, cv):
+            ret _hs_fail(h, "could not generate a key on the server's curve")
         end
         repeat point.len with i:
             _put8(peer, _rdat(point, i))

--- a/tests/en/general/_litalpha.salam
+++ b/tests/en/general/_litalpha.salam
@@ -1,0 +1,26 @@
+/*
+ * Salam Programming Language (2024-2026)
+ *
+ *   +-------------------+
+ *   |     S A L A M     |
+ *   +-------------------+
+ *
+ * Designed by Seyyed Ali Mohammadiyeh and the Salam Team
+ * Born from a decade of language design experience (since 2018)
+ *
+ * Repository: https://github.com/SalamLang/Salam
+ *
+ */
+
+// Helper for general/pkg_struct_lit: one of two packages that export a
+// struct called 'Input'.
+package litalpha
+
+pub struct Input:
+    pub a: str = "alpha-a"
+    pub n: int = 1
+end
+
+pub func Show(x: Input): str:
+    ret "alpha " + x.a + " " + x.n
+end

--- a/tests/en/general/_litbeta.salam
+++ b/tests/en/general/_litbeta.salam
@@ -1,0 +1,27 @@
+/*
+ * Salam Programming Language (2024-2026)
+ *
+ *   +-------------------+
+ *   |     S A L A M     |
+ *   +-------------------+
+ *
+ * Designed by Seyyed Ali Mohammadiyeh and the Salam Team
+ * Born from a decade of language design experience (since 2018)
+ *
+ * Repository: https://github.com/SalamLang/Salam
+ *
+ */
+
+// Helper for general/pkg_struct_lit: the other 'Input'. Same field names on
+// purpose - where the two shapes are assignment-compatible, binding the
+// literal to the wrong one compiles and quietly produces the wrong data.
+package litbeta
+
+pub struct Input:
+    pub a: str = "beta-a"
+    pub n: int = 2
+end
+
+pub func Show(x: Input): str:
+    ret "beta " + x.a + " " + x.n
+end

--- a/tests/en/general/_ownera.salam
+++ b/tests/en/general/_ownera.salam
@@ -1,0 +1,39 @@
+/*
+ * Salam Programming Language (2024-2026)
+ *
+ *   +-------------------+
+ *   |     S A L A M     |
+ *   +-------------------+
+ *
+ * Designed by Seyyed Ali Mohammadiyeh and the Salam Team
+ * Born from a decade of language design experience (since 2018)
+ *
+ * Repository: https://github.com/SalamLang/Salam
+ *
+ */
+
+// Helper for general/pkg_method_owner: one of two packages with a struct called
+// 'Input', each carrying its own free().
+package ownera
+
+pub struct Input:
+    pub title: str = ""
+    pub count: i64 = 0
+    pub v: Vector<i64> = Vector {}
+
+    pub func tag(): str:
+        ret "ownera"
+    end
+
+    pub func free():
+        this.v.free()
+    end
+end
+
+pub func Make(): Input:
+    mut i := Input {}
+    i.title = "a"
+    i.v.push(1 as i64)
+    i.v.push(2 as i64)
+    ret i
+end

--- a/tests/en/general/_ownerb.salam
+++ b/tests/en/general/_ownerb.salam
@@ -1,0 +1,41 @@
+/*
+ * Salam Programming Language (2024-2026)
+ *
+ *   +-------------------+
+ *   |     S A L A M     |
+ *   +-------------------+
+ *
+ * Designed by Seyyed Ali Mohammadiyeh and the Salam Team
+ * Born from a decade of language design experience (since 2018)
+ *
+ * Repository: https://github.com/SalamLang/Salam
+ *
+ */
+
+// Helper for general/pkg_method_owner: the other 'Input'. The bools and the i32
+// put its Vector at a different offset from ownera's, which is what turned a
+// mis-bound method into a bad free() rather than merely a wrong answer.
+package ownerb
+
+pub struct Input:
+    pub flag: bool = false
+    pub width: i32 = 0
+    pub seen: bool = false
+    pub total: i64 = 0
+    pub v: Vector<i64> = Vector {}
+
+    pub func tag(): str:
+        ret "ownerb"
+    end
+
+    pub func free():
+        this.v.free()
+    end
+end
+
+pub func Make(): Input:
+    mut i := Input {}
+    i.flag = true
+    i.v.push(7 as i64)
+    ret i
+end

--- a/tests/en/general/_pkgconst_a.salam
+++ b/tests/en/general/_pkgconst_a.salam
@@ -1,0 +1,31 @@
+/*
+ * Salam Programming Language (2024-2026)
+ *
+ *   +-------------------+
+ *   |     S A L A M     |
+ *   +-------------------+
+ *
+ * Designed by Seyyed Ali Mohammadiyeh and the Salam Team
+ * Born from a decade of language design experience (since 2018)
+ *
+ * Repository: https://github.com/SalamLang/Salam
+ *
+ */
+
+// Helper for general/pkg_globals: a module-level constant whose name a
+// sibling module also uses. Not 'pub' on purpose - a private global still
+// collided, because globals used to be emitted under their bare Salam name
+// into one flat C namespace.
+package pkgconsta
+
+const COLS := "a-cols"
+mut counter := 0
+
+pub func Get(): str:
+    ret COLS
+end
+
+pub func Bump(): int:
+    counter += 1
+    ret counter
+end

--- a/tests/en/general/_pkgconst_b.salam
+++ b/tests/en/general/_pkgconst_b.salam
@@ -1,0 +1,28 @@
+/*
+ * Salam Programming Language (2024-2026)
+ *
+ *   +-------------------+
+ *   |     S A L A M     |
+ *   +-------------------+
+ *
+ * Designed by Seyyed Ali Mohammadiyeh and the Salam Team
+ * Born from a decade of language design experience (since 2018)
+ *
+ * Repository: https://github.com/SalamLang/Salam
+ *
+ */
+
+// Helper for general/pkg_globals: the same two global names again.
+package pkgconstb
+
+const COLS := "b-cols"
+mut counter := 100
+
+pub func Get(): str:
+    ret COLS
+end
+
+pub func Bump(): int:
+    counter += 1
+    ret counter
+end

--- a/tests/en/general/_pkghandlers.salam
+++ b/tests/en/general/_pkghandlers.salam
@@ -1,0 +1,25 @@
+/*
+ * Salam Programming Language (2024-2026)
+ *
+ *   +-------------------+
+ *   |     S A L A M     |
+ *   +-------------------+
+ *
+ * Designed by Seyyed Ali Mohammadiyeh and the Salam Team
+ * Born from a decade of language design experience (since 2018)
+ *
+ * Repository: https://github.com/SalamLang/Salam
+ *
+ */
+
+// Helper for general/pkg_func_value: handlers that a route table in another
+// module points at by address.
+package pkghandlers
+
+pub func home(ctx: i64):
+    println "pkghandlers.home ", ctx
+end
+
+pub func about(ctx: i64):
+    println "pkghandlers.about ", ctx
+end

--- a/tests/en/general/json_unicode_escape.out
+++ b/tests/en/general/json_unicode_escape.out
@@ -1,0 +1,9 @@
+Get:     مانتو
+Decode:  مانتو
+Get:     😀
+Decode:  😀
+Get:     aAb	c
+Decode:  aAb	c
+Get:     [�]
+Decode:  [�]
+"bel\u0007end"

--- a/tests/en/general/json_unicode_escape.salam
+++ b/tests/en/general/json_unicode_escape.salam
@@ -1,0 +1,44 @@
+/*
+ * Salam Programming Language (2024-2026)
+ *
+ *   +-------------------+
+ *   |     S A L A M     |
+ *   +-------------------+
+ *
+ * Designed by Seyyed Ali Mohammadiyeh and the Salam Team
+ * Born from a decade of language design experience (since 2018)
+ *
+ * Repository: https://github.com/SalamLang/Salam
+ *
+ */
+
+// json.dumps (Python) and json_encode (PHP) escape every non-ASCII character
+// by default, so \uXXXX - not raw UTF-8 - is what a Salam service actually
+// receives from such a client. json.Get used to hand back the escape as
+// literal text and json.Decode truncated each code point to its low byte, so
+// every Persian name arrived as mojibake with no error anywhere.
+package main
+
+import encoding.json
+import encoding.value
+import encoding.encerr
+
+func show(src: str, key: str):
+    println "Get:    ", json.Get(src, key)
+    mut e := encerr.EncodingError {}
+    mut v := json.Decode(src, e)
+    println "Decode: ", value.AsString(value.ObjectGet(v, key))
+    value.ValueFree(v)
+end
+
+func main:
+    // "مانتو", the way json.dumps writes it.
+    show("{\"n\":\"\\u0645\\u0627\\u0646\\u062a\\u0648\"}", "n")
+    // A non-BMP code point arrives as a UTF-16 surrogate pair.
+    show("{\"n\":\"\\uD83D\\uDE00\"}", "n")
+    // The short escapes still resolve, and an ASCII \u is just that byte.
+    show("{\"n\":\"a\\u0041b\\tc\"}", "n")
+    // An unpaired surrogate is not a code point: U+FFFD, never CESU-8.
+    show("{\"n\":\"[\\uD83D]\"}", "n")
+    println json.Str("bel\x07end")
+end

--- a/tests/en/general/net_mime.out
+++ b/tests/en/general/net_mime.out
@@ -16,3 +16,9 @@ true
 true
 true
 true
+true
+true
+true
+true
+true
+true

--- a/tests/en/general/net_mime.salam
+++ b/tests/en/general/net_mime.salam
@@ -21,6 +21,15 @@ func main:
     println mime.MimeType("mystery.xyz") == "application/octet-stream"
     println mime.StatusText(404) == "Not Found"
     println mime.StatusText(999) == "Unknown"
+    // Registered codes outside the handful the table used to carry: these all
+    // came back as "Unknown", so `Ctx_status(ctx, 202)` wrote
+    // "HTTP/1.1 202 Unknown" onto the wire.
+    println mime.StatusText(202) == "Accepted"
+    println mime.StatusText(103) == "Early Hints"
+    println mime.StatusText(308) == "Permanent Redirect"
+    println mime.StatusText(418) == "I'm a teapot"
+    println mime.StatusText(451) == "Unavailable For Legal Reasons"
+    println mime.StatusText(511) == "Network Authentication Required"
 
     ct := mime.ParseContentType("multipart/form-data; boundary=abc123; charset=utf-8")
     println ct.media_type == "multipart/form-data"

--- a/tests/en/general/pkg_func_value.out
+++ b/tests/en/general/pkg_func_value.out
@@ -1,0 +1,4 @@
+true
+pkghandlers.home  1
+pkghandlers.about  2
+main.local_one  3

--- a/tests/en/general/pkg_func_value.salam
+++ b/tests/en/general/pkg_func_value.salam
@@ -1,0 +1,35 @@
+/*
+ * Salam Programming Language (2024-2026)
+ *
+ *   +-------------------+
+ *   |     S A L A M     |
+ *   +-------------------+
+ *
+ * Designed by Seyyed Ali Mohammadiyeh and the Salam Team
+ * Born from a decade of language design experience (since 2018)
+ *
+ * Repository: https://github.com/SalamLang/Salam
+ *
+ */
+
+// A bare function name decays to its address; a package-qualified one used to
+// be rejected outright ("function 'pkg.f' used as a value (call it)"), which
+// forced every handler a router points at into the same file as the table.
+package main
+
+import pkghandlers "_pkghandlers.salam"
+
+func local_one(ctx: i64):
+    println "main.local_one ", ctx
+end
+
+func main:
+    a := pkghandlers.home
+    b := pkghandlers.about
+    c := local_one
+    d := &pkghandlers.home
+    println (d as i64) == a
+    callhandler(a, 1)
+    callhandler(b, 2)
+    callhandler(c, 3)
+end

--- a/tests/en/general/pkg_globals.out
+++ b/tests/en/general/pkg_globals.out
@@ -1,0 +1,3 @@
+a-cols   b-cols   main-cols
+1   101
+2   102

--- a/tests/en/general/pkg_globals.salam
+++ b/tests/en/general/pkg_globals.salam
@@ -1,0 +1,31 @@
+/*
+ * Salam Programming Language (2024-2026)
+ *
+ *   +-------------------+
+ *   |     S A L A M     |
+ *   +-------------------+
+ *
+ * Designed by Seyyed Ali Mohammadiyeh and the Salam Team
+ * Born from a decade of language design experience (since 2018)
+ *
+ * Repository: https://github.com/SalamLang/Salam
+ *
+ */
+
+// Two modules that each declare 'COLS' and 'counter'. The C backend used to
+// emit both under their bare names and the link failed with "multiple
+// definition of `COLS'"; the LLVM backend put the whole program in one
+// module, skipped the second as already-emitted, and silently gave both
+// modules the first one's storage.
+package main
+
+import pkgconsta "_pkgconst_a.salam"
+import pkgconstb "_pkgconst_b.salam"
+
+const COLS := "main-cols"
+
+func main:
+    println pkgconsta.Get(), " ", pkgconstb.Get(), " ", COLS
+    println pkgconsta.Bump(), " ", pkgconstb.Bump()
+    println pkgconsta.Bump(), " ", pkgconstb.Bump()
+end

--- a/tests/en/general/pkg_method_owner.out
+++ b/tests/en/general/pkg_method_owner.out
@@ -1,0 +1,4 @@
+ownera   2   ownerb   1
+ownera   2   ownerb   1
+ownera   2   ownerb   1
+ok

--- a/tests/en/general/pkg_method_owner.salam
+++ b/tests/en/general/pkg_method_owner.salam
@@ -1,0 +1,35 @@
+/*
+ * Salam Programming Language (2024-2026)
+ *
+ *   +-------------------+
+ *   |     S A L A M     |
+ *   +-------------------+
+ *
+ * Designed by Seyyed Ali Mohammadiyeh and the Salam Team
+ * Born from a decade of language design experience (since 2018)
+ *
+ * Repository: https://github.com/SalamLang/Salam
+ *
+ */
+
+// Two packages with a struct of the same name, each with its own methods.
+// The LLVM backend mangled a method on its owner's DECLARED name only, so
+// ownera.Input.free and ownerb.Input.free both became @salam_Input_free: one
+// body was emitted and every call bound to it. Reading 'this' at the other
+// struct's field offsets handed free() a Vector receiver eight bytes past its
+// real address, and the process died in the allocator.
+package main
+
+import ownera "_ownera.salam"
+import ownerb "_ownerb.salam"
+
+func main:
+    repeat 3:
+        mut a := ownera.Make()
+        mut b := ownerb.Make()
+        println a.tag(), " ", a.v.len(), " ", b.tag(), " ", b.v.len()
+        a.free()
+        b.free()
+    end
+    println "ok"
+end

--- a/tests/en/general/pkg_struct_lit.out
+++ b/tests/en/general/pkg_struct_lit.out
@@ -1,0 +1,2 @@
+alpha x 1
+beta beta-a 9

--- a/tests/en/general/pkg_struct_lit.salam
+++ b/tests/en/general/pkg_struct_lit.salam
@@ -1,0 +1,29 @@
+/*
+ * Salam Programming Language (2024-2026)
+ *
+ *   +-------------------+
+ *   |     S A L A M     |
+ *   +-------------------+
+ *
+ * Designed by Seyyed Ali Mohammadiyeh and the Salam Team
+ * Born from a decade of language design experience (since 2018)
+ *
+ * Repository: https://github.com/SalamLang/Salam
+ *
+ */
+
+// A package-qualified struct literal has to bind to that package's type. It
+// used to be resolved by bare name, first match wins: 'litbeta.Input { n = 9 }'
+// became litalpha's struct, took litalpha's field defaults, and dropped the
+// initializers the caller wrote for fields the other struct does not have.
+package main
+
+import litalpha "_litalpha.salam"
+import litbeta "_litbeta.salam"
+
+func main:
+    x := litalpha.Input { a = "x" }
+    y := litbeta.Input { n = 9 }
+    println litalpha.Show(x)
+    println litbeta.Show(y)
+end

--- a/tests/en/llvm/_litalpha.salam
+++ b/tests/en/llvm/_litalpha.salam
@@ -1,0 +1,26 @@
+/*
+ * Salam Programming Language (2024-2026)
+ *
+ *   +-------------------+
+ *   |     S A L A M     |
+ *   +-------------------+
+ *
+ * Designed by Seyyed Ali Mohammadiyeh and the Salam Team
+ * Born from a decade of language design experience (since 2018)
+ *
+ * Repository: https://github.com/SalamLang/Salam
+ *
+ */
+
+// Helper for llvm/pkg_struct_lit: one of two packages that export a
+// struct called 'Input'.
+package litalpha
+
+pub struct Input:
+    pub a: str = "alpha-a"
+    pub n: int = 1
+end
+
+pub func Show(x: Input): str:
+    ret "alpha " + x.a + " " + x.n
+end

--- a/tests/en/llvm/_litbeta.salam
+++ b/tests/en/llvm/_litbeta.salam
@@ -1,0 +1,27 @@
+/*
+ * Salam Programming Language (2024-2026)
+ *
+ *   +-------------------+
+ *   |     S A L A M     |
+ *   +-------------------+
+ *
+ * Designed by Seyyed Ali Mohammadiyeh and the Salam Team
+ * Born from a decade of language design experience (since 2018)
+ *
+ * Repository: https://github.com/SalamLang/Salam
+ *
+ */
+
+// Helper for llvm/pkg_struct_lit: the other 'Input'. Same field names on
+// purpose - where the two shapes are assignment-compatible, binding the
+// literal to the wrong one compiles and quietly produces the wrong data.
+package litbeta
+
+pub struct Input:
+    pub a: str = "beta-a"
+    pub n: int = 2
+end
+
+pub func Show(x: Input): str:
+    ret "beta " + x.a + " " + x.n
+end

--- a/tests/en/llvm/_ownera.salam
+++ b/tests/en/llvm/_ownera.salam
@@ -1,0 +1,39 @@
+/*
+ * Salam Programming Language (2024-2026)
+ *
+ *   +-------------------+
+ *   |     S A L A M     |
+ *   +-------------------+
+ *
+ * Designed by Seyyed Ali Mohammadiyeh and the Salam Team
+ * Born from a decade of language design experience (since 2018)
+ *
+ * Repository: https://github.com/SalamLang/Salam
+ *
+ */
+
+// Helper for llvm/pkg_method_owner: one of two packages with a struct called
+// 'Input', each carrying its own free().
+package ownera
+
+pub struct Input:
+    pub title: str = ""
+    pub count: i64 = 0
+    pub v: Vector<i64> = Vector {}
+
+    pub func tag(): str:
+        ret "ownera"
+    end
+
+    pub func free():
+        this.v.free()
+    end
+end
+
+pub func Make(): Input:
+    mut i := Input {}
+    i.title = "a"
+    i.v.push(1 as i64)
+    i.v.push(2 as i64)
+    ret i
+end

--- a/tests/en/llvm/_ownerb.salam
+++ b/tests/en/llvm/_ownerb.salam
@@ -1,0 +1,41 @@
+/*
+ * Salam Programming Language (2024-2026)
+ *
+ *   +-------------------+
+ *   |     S A L A M     |
+ *   +-------------------+
+ *
+ * Designed by Seyyed Ali Mohammadiyeh and the Salam Team
+ * Born from a decade of language design experience (since 2018)
+ *
+ * Repository: https://github.com/SalamLang/Salam
+ *
+ */
+
+// Helper for llvm/pkg_method_owner: the other 'Input'. The bools and the i32
+// put its Vector at a different offset from ownera's, which is what turned a
+// mis-bound method into a bad free() rather than merely a wrong answer.
+package ownerb
+
+pub struct Input:
+    pub flag: bool = false
+    pub width: i32 = 0
+    pub seen: bool = false
+    pub total: i64 = 0
+    pub v: Vector<i64> = Vector {}
+
+    pub func tag(): str:
+        ret "ownerb"
+    end
+
+    pub func free():
+        this.v.free()
+    end
+end
+
+pub func Make(): Input:
+    mut i := Input {}
+    i.flag = true
+    i.v.push(7 as i64)
+    ret i
+end

--- a/tests/en/llvm/_pkgconst_a.salam
+++ b/tests/en/llvm/_pkgconst_a.salam
@@ -1,0 +1,31 @@
+/*
+ * Salam Programming Language (2024-2026)
+ *
+ *   +-------------------+
+ *   |     S A L A M     |
+ *   +-------------------+
+ *
+ * Designed by Seyyed Ali Mohammadiyeh and the Salam Team
+ * Born from a decade of language design experience (since 2018)
+ *
+ * Repository: https://github.com/SalamLang/Salam
+ *
+ */
+
+// Helper for llvm/pkg_globals: a module-level constant whose name a
+// sibling module also uses. Not 'pub' on purpose - a private global still
+// collided, because globals used to be emitted under their bare Salam name
+// into one flat C namespace.
+package pkgconsta
+
+const COLS := "a-cols"
+mut counter := 0
+
+pub func Get(): str:
+    ret COLS
+end
+
+pub func Bump(): int:
+    counter += 1
+    ret counter
+end

--- a/tests/en/llvm/_pkgconst_b.salam
+++ b/tests/en/llvm/_pkgconst_b.salam
@@ -1,0 +1,28 @@
+/*
+ * Salam Programming Language (2024-2026)
+ *
+ *   +-------------------+
+ *   |     S A L A M     |
+ *   +-------------------+
+ *
+ * Designed by Seyyed Ali Mohammadiyeh and the Salam Team
+ * Born from a decade of language design experience (since 2018)
+ *
+ * Repository: https://github.com/SalamLang/Salam
+ *
+ */
+
+// Helper for llvm/pkg_globals: the same two global names again.
+package pkgconstb
+
+const COLS := "b-cols"
+mut counter := 100
+
+pub func Get(): str:
+    ret COLS
+end
+
+pub func Bump(): int:
+    counter += 1
+    ret counter
+end

--- a/tests/en/llvm/_pkghandlers.salam
+++ b/tests/en/llvm/_pkghandlers.salam
@@ -1,0 +1,25 @@
+/*
+ * Salam Programming Language (2024-2026)
+ *
+ *   +-------------------+
+ *   |     S A L A M     |
+ *   +-------------------+
+ *
+ * Designed by Seyyed Ali Mohammadiyeh and the Salam Team
+ * Born from a decade of language design experience (since 2018)
+ *
+ * Repository: https://github.com/SalamLang/Salam
+ *
+ */
+
+// Helper for llvm/pkg_func_value: handlers that a route table in another
+// module points at by address.
+package pkghandlers
+
+pub func home(ctx: i64):
+    println "pkghandlers.home ", ctx
+end
+
+pub func about(ctx: i64):
+    println "pkghandlers.about ", ctx
+end

--- a/tests/en/llvm/pkg_func_value.out
+++ b/tests/en/llvm/pkg_func_value.out
@@ -1,0 +1,4 @@
+true
+pkghandlers.home  1
+pkghandlers.about  2
+main.local_one  3

--- a/tests/en/llvm/pkg_func_value.salam
+++ b/tests/en/llvm/pkg_func_value.salam
@@ -1,0 +1,35 @@
+/*
+ * Salam Programming Language (2024-2026)
+ *
+ *   +-------------------+
+ *   |     S A L A M     |
+ *   +-------------------+
+ *
+ * Designed by Seyyed Ali Mohammadiyeh and the Salam Team
+ * Born from a decade of language design experience (since 2018)
+ *
+ * Repository: https://github.com/SalamLang/Salam
+ *
+ */
+
+// A bare function name decays to its address; a package-qualified one used to
+// be rejected outright ("function 'pkg.f' used as a value (call it)"), which
+// forced every handler a router points at into the same file as the table.
+package main
+
+import pkghandlers "_pkghandlers.salam"
+
+func local_one(ctx: i64):
+    println "main.local_one ", ctx
+end
+
+func main:
+    a := pkghandlers.home
+    b := pkghandlers.about
+    c := local_one
+    d := &pkghandlers.home
+    println (d as i64) == a
+    callhandler(a, 1)
+    callhandler(b, 2)
+    callhandler(c, 3)
+end

--- a/tests/en/llvm/pkg_globals.out
+++ b/tests/en/llvm/pkg_globals.out
@@ -1,0 +1,3 @@
+a-cols   b-cols   main-cols
+1   101
+2   102

--- a/tests/en/llvm/pkg_globals.salam
+++ b/tests/en/llvm/pkg_globals.salam
@@ -1,0 +1,31 @@
+/*
+ * Salam Programming Language (2024-2026)
+ *
+ *   +-------------------+
+ *   |     S A L A M     |
+ *   +-------------------+
+ *
+ * Designed by Seyyed Ali Mohammadiyeh and the Salam Team
+ * Born from a decade of language design experience (since 2018)
+ *
+ * Repository: https://github.com/SalamLang/Salam
+ *
+ */
+
+// Two modules that each declare 'COLS' and 'counter'. The C backend used to
+// emit both under their bare names and the link failed with "multiple
+// definition of `COLS'"; the LLVM backend put the whole program in one
+// module, skipped the second as already-emitted, and silently gave both
+// modules the first one's storage.
+package main
+
+import pkgconsta "_pkgconst_a.salam"
+import pkgconstb "_pkgconst_b.salam"
+
+const COLS := "main-cols"
+
+func main:
+    println pkgconsta.Get(), " ", pkgconstb.Get(), " ", COLS
+    println pkgconsta.Bump(), " ", pkgconstb.Bump()
+    println pkgconsta.Bump(), " ", pkgconstb.Bump()
+end

--- a/tests/en/llvm/pkg_method_owner.out
+++ b/tests/en/llvm/pkg_method_owner.out
@@ -1,0 +1,4 @@
+ownera   2   ownerb   1
+ownera   2   ownerb   1
+ownera   2   ownerb   1
+ok

--- a/tests/en/llvm/pkg_method_owner.salam
+++ b/tests/en/llvm/pkg_method_owner.salam
@@ -1,0 +1,35 @@
+/*
+ * Salam Programming Language (2024-2026)
+ *
+ *   +-------------------+
+ *   |     S A L A M     |
+ *   +-------------------+
+ *
+ * Designed by Seyyed Ali Mohammadiyeh and the Salam Team
+ * Born from a decade of language design experience (since 2018)
+ *
+ * Repository: https://github.com/SalamLang/Salam
+ *
+ */
+
+// Two packages with a struct of the same name, each with its own methods.
+// The LLVM backend mangled a method on its owner's DECLARED name only, so
+// ownera.Input.free and ownerb.Input.free both became @salam_Input_free: one
+// body was emitted and every call bound to it. Reading 'this' at the other
+// struct's field offsets handed free() a Vector receiver eight bytes past its
+// real address, and the process died in the allocator.
+package main
+
+import ownera "_ownera.salam"
+import ownerb "_ownerb.salam"
+
+func main:
+    repeat 3:
+        mut a := ownera.Make()
+        mut b := ownerb.Make()
+        println a.tag(), " ", a.v.len(), " ", b.tag(), " ", b.v.len()
+        a.free()
+        b.free()
+    end
+    println "ok"
+end

--- a/tests/en/llvm/pkg_struct_lit.out
+++ b/tests/en/llvm/pkg_struct_lit.out
@@ -1,0 +1,2 @@
+alpha x 1
+beta beta-a 9

--- a/tests/en/llvm/pkg_struct_lit.salam
+++ b/tests/en/llvm/pkg_struct_lit.salam
@@ -1,0 +1,29 @@
+/*
+ * Salam Programming Language (2024-2026)
+ *
+ *   +-------------------+
+ *   |     S A L A M     |
+ *   +-------------------+
+ *
+ * Designed by Seyyed Ali Mohammadiyeh and the Salam Team
+ * Born from a decade of language design experience (since 2018)
+ *
+ * Repository: https://github.com/SalamLang/Salam
+ *
+ */
+
+// A package-qualified struct literal has to bind to that package's type. It
+// used to be resolved by bare name, first match wins: 'litbeta.Input { n = 9 }'
+// became litalpha's struct, took litalpha's field defaults, and dropped the
+// initializers the caller wrote for fields the other struct does not have.
+package main
+
+import litalpha "_litalpha.salam"
+import litbeta "_litbeta.salam"
+
+func main:
+    x := litalpha.Input { a = "x" }
+    y := litbeta.Input { n = 9 }
+    println litalpha.Show(x)
+    println litbeta.Show(y)
+end


### PR DESCRIPTION
Follow-up to #1526. That merge took the Windows release gate from 64 failing
tests to 1, and everything else green - Linux, macOS, and all six other build
legs passed, so `Create Release` was one job away from publishing v0.3.1.

### The last Windows failure

`general/en/termcore` expected `ansi = true` and got `false`.

`EnableAnsi()` on Windows called `SetConsoleMode`, which fails on a handle that
is not a console. CI redirects stdout - the same run reports
`isterminal = false` - so it returned false. On POSIX the identical redirected
stream reports `true`, and rightly: there is no console mode to switch and the
escape bytes reach the file untouched either way.

So the platforms disagreed about a case neither of them has to do anything
about. `GetConsoleMode` distinguishes them - it only succeeds on a real console
handle - so a non-console now reports `true`, and a `false` means what it
should: this IS a console and virtual-terminal processing could not be enabled.

This expectation had never actually run on Windows. `termcore` was one of the
five files the E070 unreachable-`ret` error stopped from building there at all,
which #1526 fixed.

### Also in this PR

- **`std/tls`** - generate the ECDHE key on the curve the server actually
  picked, plus the http changes that go with it.
- **`compiler/`** - the self-hosted port of the global-name mangling already on
  main from #1526: module-level globals carry their package in the emitted C
  name, a package-qualified struct literal binds to that package's type, and a
  package-qualified function decays to its address; same treatment on the LLVM
  side for globals, members and method symbol names.
- **tests** - 9 new cases covering same-name packages across modules, qualified
  struct literals and `\uXXXX` escapes.

### Testing

Full suite locally: **1400 passed** (up from 1391 - the new tests), 2 failures,
both environmental and both reproducing identically on pre-change `main` (port
8080 is bound on this machine; no musl sysroot for the sqlite cross test). LLVM
corpus sweep: 0 codegen failures. `prek run --all-files` exits 0. Repo-wide
clang-format clean. The self-hosted compiler builds and bootstraps
stage2 -> stage3; the parity gate is what CI reports on it.

Windows runtime behaviour of the `GetConsoleMode` change is the one thing that
cannot be exercised locally - it type-checks clean for
`x86_64-w64-windows-gnu` and the five term tests still pass on Linux.

Titled `release:` deliberately: that is what makes the gate run on main, and
what lets `Create Release` publish v0.3.1.
