### PR TITLE
ci: stop mariadb's unconditional CURL probe on the Windows job

### DIFF
--- a/.github/workflows/compiler-release.yml
+++ b/.github/workflows/compiler-release.yml
@@ -1114,10 +1114,26 @@ jobs:
             # shellcheck disable=SC2086
             # -DCMAKE_COMPILE_WARNING_AS_ERROR=OFF: see the Linux job's copy
             # of build_mariadb for why this is load-bearing on musl targets.
+            #
+            # WITH_CURL=OFF is not enough to keep curl out: CMakeLists.txt:74
+            # runs FIND_PACKAGE(CURL) unconditionally, before it ever looks at
+            # the option. On this runner that finds MSYS2's CURLConfig.cmake,
+            # which find_dependency(Brotli)'s its way into a FindBrotli.cmake
+            # that calls pkg_check_modules - a command that only exists once
+            # FindPkgConfig has been loaded, and ssl_args deliberately sets
+            # CMAKE_DISABLE_FIND_PACKAGE_PkgConfig=ON to stop FindOpenSSL
+            # resolving the wrong OpenSSL. So the two settings collided:
+            # "Unknown CMake command pkg_check_modules", and every musl target
+            # lost its mariadb again. Disabling the CURL lookup outright is
+            # what WITH_CURL=OFF was asking for anyway.
+            #
+            # This only surfaced once the cross compiler could link at all -
+            # before that CMake stopped at its own compiler check.
             if ( cd "$mb_dir" \
                  && cmake /tmp/mariadb-src -G "MSYS Makefiles" -DCMAKE_BUILD_TYPE=Release \
                       -DCMAKE_COMPILE_WARNING_AS_ERROR=OFF \
-                      -DWITH_UNIT_TESTS=OFF -DWITH_CURL=OFF $ssl_args $extra_args \
+                      -DWITH_UNIT_TESTS=OFF -DWITH_CURL=OFF \
+                      -DCMAKE_DISABLE_FIND_PACKAGE_CURL=ON $ssl_args $extra_args \
                  && cmake --build . --target mariadbclient -j"$(nproc)" ) \
                  >"$mb_dir.log" 2>&1; then
               LIB=$(find "$mb_dir" -name "libmariadbclient.a" | head -1)


### PR DESCRIPTION
Third and, I hope, last layer of the cross-musl mariadb failure. #1528 got the
compiler working; this is what it uncovered.

### What #1528 achieved

Confirmed in the Windows job on `6176aaa2`:

```
-- Detecting C compiler ABI info - done          (was: failed)
-- Check for working C compiler: ...gcc.bat - skipped   (was: broken)
```

and the sysroots re-fetched with the three added runtime objects. So the
linker selection and the sysroot contents are both right now.

### What it uncovered

CMake got past its own compiler check and straight into the next wall:

```
CMake Error at .../FindBrotli.cmake:46 (pkg_check_modules):
  Unknown CMake command "pkg_check_modules".
Call Stack:
  ... CURLConfig.cmake:93 (find_dependency)
  ... CMakeLists.txt:74 (FIND_PACKAGE)
```

`-DWITH_CURL=OFF` is already passed and does **not** prevent this.
mariadb-connector-c runs `FIND_PACKAGE(CURL)` at `CMakeLists.txt:74`
unconditionally, before it consults the option - verified against the pinned
`v3.4.9` source, where line 74 is a bare `FIND_PACKAGE(CURL)`, not `REQUIRED`.

On this runner that resolves MSYS2's `CURLConfig.cmake`, which
`find_dependency(Brotli)`'s into a `FindBrotli.cmake` that calls
`pkg_check_modules`. That command only exists once `FindPkgConfig` has been
loaded - and `ssl_args` deliberately sets
`-DCMAKE_DISABLE_FIND_PACKAGE_PkgConfig=ON`, which is there to stop
`FindOpenSSL` resolving the host's OpenSSL instead of the cross-built one.

So the two settings collided, and every musl target lost its mariadb again.
It could not have surfaced before, because CMake never previously got past
its compiler check.

### Fix

`-DCMAKE_DISABLE_FIND_PACKAGE_CURL=ON`, which makes the unconditional lookup a
no-op - what `WITH_CURL=OFF` was asking for in the first place. Because the
`find_package` is not `REQUIRED`, making it not-found is safe.

No cache key change needed: `need_build` gates on
`/c/extralibs/<target>/libmariadb.a`, which still does not exist for the musl
targets, so they rebuild. The sysroot cache should now *hit* on `v3` and carry
the eight files.

Watch this PR's Windows job for `built libmariadb.a for <target>` in "Build
static third-party libs", where the warnings have been.
