### PR TITLE
android: drop the location permissions Bazaar flagged

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,13 +5,6 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-
-    <uses-feature
-        android:name="android.hardware.location"
-        android:required="false" />
-
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/android/app/src/main/java/ir/salamlang/app/MainActivity.kt
+++ b/android/app/src/main/java/ir/salamlang/app/MainActivity.kt
@@ -1,6 +1,5 @@
 package ir.salamlang.app
 
-import android.Manifest
 import android.annotation.SuppressLint
 import android.content.ActivityNotFoundException
 import android.content.Intent
@@ -17,7 +16,6 @@ import android.view.ViewGroup
 import android.view.animation.DecelerateInterpolator
 import android.webkit.ConsoleMessage
 import android.webkit.CookieManager
-import android.webkit.GeolocationPermissions
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebResourceError
@@ -33,7 +31,6 @@ import androidx.activity.ComponentActivity
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.ViewCompat
@@ -53,22 +50,9 @@ class MainActivity : ComponentActivity() {
     private val splashTimeoutRunnable = Runnable { hideSplash() }
     private var splashHidden = false
 
-    private var geolocationOrigin: String? = null
-    private var geolocationCallback: GeolocationPermissions.Callback? = null
-
     private var filePathCallback: ValueCallback<Array<Uri>>? = null
 
     private var popupWebView: WebView? = null
-
-    private val locationPermissionLauncher =
-        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { result ->
-            val granted =
-                result[Manifest.permission.ACCESS_FINE_LOCATION] == true ||
-                    result[Manifest.permission.ACCESS_COARSE_LOCATION] == true
-            geolocationCallback?.invoke(geolocationOrigin.orEmpty(), granted, false)
-            geolocationCallback = null
-            geolocationOrigin = null
-        }
 
     private val fileChooserLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
@@ -147,7 +131,6 @@ class MainActivity : ComponentActivity() {
         settings.apply {
             javaScriptEnabled = true
             domStorageEnabled = true
-            setGeolocationEnabled(true)
             javaScriptCanOpenWindowsAutomatically = true
             setSupportMultipleWindows(true)
             loadWithOverviewMode = true
@@ -240,15 +223,6 @@ class MainActivity : ComponentActivity() {
             },
         )
     }
-
-    private fun hasLocationPermission(): Boolean =
-        ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) ==
-            PackageManager.PERMISSION_GRANTED ||
-            ContextCompat.checkSelfPermission(
-                this,
-                Manifest.permission.ACCESS_COARSE_LOCATION,
-            ) ==
-            PackageManager.PERMISSION_GRANTED
 
     private fun hideSplash() {
         if (splashHidden) return
@@ -411,24 +385,6 @@ class MainActivity : ComponentActivity() {
                 "console[${message.messageLevel()}]: ${message.message()} (${message.sourceId()}:${message.lineNumber()})",
             )
             return true
-        }
-
-        override fun onGeolocationPermissionsShowPrompt(
-            origin: String,
-            callback: GeolocationPermissions.Callback,
-        ) {
-            if (hasLocationPermission()) {
-                callback.invoke(origin, true, false)
-            } else {
-                geolocationOrigin = origin
-                geolocationCallback = callback
-                locationPermissionLauncher.launch(
-                    arrayOf(
-                        Manifest.permission.ACCESS_FINE_LOCATION,
-                        Manifest.permission.ACCESS_COARSE_LOCATION,
-                    ),
-                )
-            }
         }
 
         override fun onShowFileChooser(

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -8,5 +8,4 @@
     <string name="error_no_connection_message">لطفاً اتصال اینترنت خود را بررسی کرده و دوباره تلاش کنید.</string>
     <string name="retry">تلاش مجدد</string>
 
-    <string name="location_permission_rationale">برای نمایش نقشه و موقعیت شما روی آن، به دسترسی موقعیت مکانی نیاز داریم.</string>
 </resources>


### PR DESCRIPTION
بازار (Cafe Bazaar) flags `ACCESS_FINE_LOCATION` and `ACCESS_COARSE_LOCATION`
as dangerous permissions. We do not need either, so this removes them rather
than justifying them to the reviewer.

### Why they were there, and why they are not needed

The app is a WebView wrapper. The permissions existed for exactly one reason:
`onGeolocationPermissionsShowPrompt`, so that if the loaded page asked for the
HTML5 Geolocation API, the app could forward the request to Android.

That page is `HOME_URL = "https://salamlang.github.io/Salam"`, and nothing in
`website/`, `editor/`, `docs/` or `std/` ever calls `navigator.geolocation` /
`getCurrentPosition` / `watchPosition`. The prompt therefore never fires, the
permission is never requested, and the capability has never done anything -
it just sits in the manifest looking alarming to a store reviewer.

### What is removed

- both `<uses-permission>` entries
- `<uses-feature android:name="android.hardware.location">`
- `setGeolocationEnabled(true)` on the WebView
- the `onGeolocationPermissionsShowPrompt` override
- `hasLocationPermission()`
- `locationPermissionLauncher` and the `geolocationOrigin` /
  `geolocationCallback` fields
- three imports left unused by the above (`android.Manifest`,
  `android.webkit.GeolocationPermissions`, `androidx.core.content.ContextCompat`)
- a `strings.xml` entry, `location_permission_rationale`, which was never
  referenced and described "showing your location on a map" - a screen this
  app does not have. It looks like it came from a template.

`PackageManager` and `ActivityResultContracts` are kept: both are still used
by the file chooser and intent handling.

### Checks

`ktlint` clean, `prek run --all-files` clean, and both `AndroidManifest.xml`
and `strings.xml` still parse. The Android build gate on this PR compiles it.

After this the app declares only `INTERNET` and `ACCESS_NETWORK_STATE`, which
is what a WebView shell actually needs.
