### PR TITLE
ci: make the release build actually reuse its cached third-party libs

### DIFF
--- a/.github/workflows/compiler-release.yml
+++ b/.github/workflows/compiler-release.yml
@@ -723,21 +723,51 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Cache Homebrew downloads
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Restore Homebrew downloads
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/Library/Caches/Homebrew/downloads
           key: brew-dl-${{ runner.arch }}-${{ github.run_id }}
           restore-keys: |
             brew-dl-${{ runner.arch }}-
       - name: Install dependencies (static LLVM)
+        id: brewdeps
         env:
           HOMEBREW_NO_AUTO_UPDATE: '1'
           HOMEBREW_NO_INSTALL_CLEANUP: '1'
         run: |
+          # Same restore/save reasoning as the static-libs cache: keep the
+          # rolling run_id key, but only upload when the download set
+          # actually moved. A plain actions/cache stores a new copy of the
+          # whole thing on every single run, and these entries are big
+          # enough that the duplicates alone were evicting other caches.
+          # shasum, not sha256sum: macOS ships the former in the base
+          # system and has no coreutils, so sha256sum is simply absent.
+          fingerprint() {
+            find "$1" -type f 2>/dev/null \
+              | LC_ALL=C sort | shasum -a 256 | cut -d' ' -f1
+          }
+          mkdir -p "$HOME/Library/Caches/Homebrew/downloads"
+          PKGS_BEFORE=$(fingerprint "$HOME/Library/Caches/Homebrew/downloads")
+
           brew untap aws/tap || true
           brew install llvm@22 ccache
           "$(brew --prefix llvm@22)/bin/llvm-config" --version
+
+          PKGS_AFTER=$(fingerprint "$HOME/Library/Caches/Homebrew/downloads")
+          if [ -n "$PKGS_AFTER" ] && [ "$PKGS_BEFORE" = "$PKGS_AFTER" ]; then
+            echo 'changed=false' >> "$GITHUB_OUTPUT"
+            echo 'download cache unchanged; skipping cache save'
+          else
+            echo 'changed=true' >> "$GITHUB_OUTPUT"
+            echo 'download cache changed; a fresh entry will be saved'
+          fi
+      - name: Save Homebrew downloads
+        if: steps.brewdeps.outputs.changed == 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/Library/Caches/Homebrew/downloads
+          key: brew-dl-${{ runner.arch }}-${{ github.run_id }}
       - name: Cache ccache (macOS)
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -863,8 +893,8 @@ jobs:
             Write-Host "::warning::Could not configure Windows Defender exclusions: $_"
           }
 
-      - name: Cache MSYS2 packages
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Restore MSYS2 packages
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: C:\msys64\var\cache\pacman\pkg
           key: msys2-mingw64-pkgs-${{ github.run_id }}
@@ -872,11 +902,24 @@ jobs:
             msys2-mingw64-pkgs-
 
       - name: Install MINGW64 toolchain + static LLVM + LLD
+        id: msys2deps
         shell: 'C:\msys64\usr\bin\bash.exe --login -eo pipefail "{0}"'
         env:
           MSYSTEM: MINGW64
           CHERE_INVOKING: '1'
         run: |
+          # Same restore/save reasoning as the static-libs cache: keep the
+          # rolling run_id key, but only upload when the package set
+          # actually moved. A plain actions/cache stored a fresh ~300MB
+          # copy on every run, and those duplicates alone were evicting
+          # other caches out of the repo's 10GB budget.
+          fingerprint() {
+            find "$1" -type f 2>/dev/null \
+              | LC_ALL=C sort | sha256sum | cut -d' ' -f1
+          }
+          mkdir -p /c/msys64/var/cache/pacman/pkg
+          PKGS_BEFORE=$(fingerprint /c/msys64/var/cache/pacman/pkg)
+
           # clang here is a genuine multi-target cross-compiler frontend
           # (unlike gcc, it needs no target-native binary to compile - only
           # target headers via -isystem) - used below to build sqlite3/
@@ -897,6 +940,22 @@ jobs:
           gcc --version | head -1
           llvm-config --version
           clang --version | head -1
+
+          PKGS_AFTER=$(fingerprint /c/msys64/var/cache/pacman/pkg)
+          if [ -n "$PKGS_AFTER" ] && [ "$PKGS_BEFORE" = "$PKGS_AFTER" ]; then
+            echo 'changed=false' >> "$GITHUB_OUTPUT"
+            echo 'pacman package cache unchanged; skipping cache save'
+          else
+            echo 'changed=true' >> "$GITHUB_OUTPUT"
+            echo 'pacman package cache changed; a fresh entry will be saved'
+          fi
+
+      - name: Save MSYS2 packages
+        if: steps.msys2deps.outputs.changed == 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: C:\msys64\var\cache\pacman\pkg
+          key: msys2-mingw64-pkgs-${{ github.run_id }}
 
       - name: Cache ccache (Windows)
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/compiler-release.yml
+++ b/.github/workflows/compiler-release.yml
@@ -111,11 +111,24 @@ jobs:
           key: ccache-linux-${{ github.run_id }}
           restore-keys: |
             ccache-linux-
-      - name: Cache static third-party libs (sqlite3 + hiredis + openssl + mariadb, per --target=)
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # Restore/save split rather than a plain actions/cache: a cache entry is
+      # only ever written when its key MISSES, so one immutable key freezes
+      # whatever the very first run happened to produce. Any run that staged
+      # only part of the target set (a musl sysroot fetch that failed, a
+      # cross-toolchain download that 404'd) pins that partial set forever -
+      # every later run then hits the stale entry, rebuilds the missing libs
+      # from scratch, and cannot store them because the key already exists.
+      # Keying on run_id and restoring by prefix lets each run start from the
+      # newest entry and save a more complete one, so the cache converges
+      # instead of freezing. The save is skipped when nothing was built, so a
+      # fully-cached run does not re-upload an identical entry.
+      - name: Restore static third-party libs (sqlite3 + hiredis + openssl + mariadb, per --target=)
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: /tmp/extralibs
-          key: extralibs-sqlite3-3530400-hiredis-v1.4.0-openssl-3.6.3-mariadb-v3.4.9-v2
+          key: extralibs-sqlite3-3530400-hiredis-v1.4.0-openssl-3.6.3-mariadb-v3.4.9-v2-${{ github.run_id }}
+          restore-keys: |
+            extralibs-sqlite3-3530400-hiredis-v1.4.0-openssl-3.6.3-mariadb-v3.4.9-v2-
       # Static libsqlite3.a/libhiredis.a/libssl.a/libcrypto.a/libmariadb.a per
       # supported --target= triple, embedded into salam itself (see
       # SALAM_EMBED_EXTRALIBS_*_DIR below and c/src/llvm/llvm_native.c's
@@ -132,9 +145,23 @@ jobs:
       # the aarch64/i686/arm cross-toolchain - a real, ~100MB fetch - only
       # gets downloaded once per target rather than once per library.
       - name: Build static third-party libs for all --target= triples
+        id: extralibs
         run: |
           set -eu
           mkdir -p /tmp/extralibs
+          # Cheap content fingerprint, compared again at the end of this
+          # step, so the save below only runs when something was actually
+          # built. The set of paths is signal enough: every need_build*
+          # gate below builds only when its .a is missing, so anything
+          # built necessarily adds a file. Deliberately no `find -printf`
+          # (a GNU extension): if it were unsupported the error would be
+          # swallowed, both fingerprints would come back empty and equal,
+          # and the cache would silently never be saved again.
+          fingerprint() {
+            find "$1" -type f 2>/dev/null \
+              | LC_ALL=C sort | sha256sum | cut -d' ' -f1
+          }
+          EXTRALIBS_BEFORE=$(fingerprint /tmp/extralibs)
           TARGETS="x86_64-linux-musl aarch64-linux-musl i686-linux-musl arm-linux-musleabihf x86_64-w64-windows-gnu hostlibs"
           need_build() { [ ! -f "/tmp/extralibs/$2/lib$1.a" ]; }
           any_needed() { for t in $TARGETS; do need_build "$1" "$t" && return 0; done; return 1; }
@@ -503,6 +530,24 @@ jobs:
             var="SALAM_EMBED_EXTRALIBS_$(echo "$target" | tr 'a-z-' 'A-Z_')_DIR"
             echo "${var}=/tmp/extralibs/$target" >> "$GITHUB_ENV"
           done
+
+          # Fail safe towards saving: an empty fingerprint means the
+          # helper itself broke, and skipping the save on that would
+          # quietly reintroduce the very staleness this replaced.
+          EXTRALIBS_AFTER=$(fingerprint /tmp/extralibs)
+          if [ -n "$EXTRALIBS_AFTER" ] && [ "$EXTRALIBS_BEFORE" = "$EXTRALIBS_AFTER" ]; then
+            echo 'changed=false' >> "$GITHUB_OUTPUT"
+            echo 'static libs fully cached; skipping cache save'
+          else
+            echo 'changed=true' >> "$GITHUB_OUTPUT"
+            echo 'static libs changed; a fresh cache entry will be saved'
+          fi
+      - name: Save static third-party libs (sqlite3 + hiredis + openssl + mariadb, per --target=)
+        if: steps.extralibs.outputs.changed == 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /tmp/extralibs
+          key: extralibs-sqlite3-3530400-hiredis-v1.4.0-openssl-3.6.3-mariadb-v3.4.9-v2-${{ github.run_id }}
       - name: Build the flagship self-contained salam (LLVM + LLD + sysroots)
         run: |
           export CCACHE_DIR="$HOME/.ccache"; ccache --max-size=800M >/dev/null 2>&1 || true
@@ -887,11 +932,18 @@ jobs:
         # cross-compiles them with clang against exactly these sysroots.
         run: sh tools/bash/fetch-musl-sysroots.sh --out /c/muslcc --headers
 
-      - name: Cache static third-party libs (sqlite3 + hiredis + openssl + mariadb, per --target=)
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # Same restore/save split as the Linux job above, and for the same
+      # reason - see that step's comment. This job is where it bit hardest:
+      # the 4 linux-musl targets it cross-builds depend on sysroots staged a
+      # step earlier, so the entry written by the first run predated them and
+      # every run since rebuilt sqlite3/hiredis for all 4 from scratch.
+      - name: Restore static third-party libs (sqlite3 + hiredis + openssl + mariadb, per --target=)
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: C:\extralibs
-          key: extralibs-sqlite3-3530400-hiredis-v1.4.0-openssl-3.6.3-mariadb-v3.4.9-win-v3
+          key: extralibs-sqlite3-3530400-hiredis-v1.4.0-openssl-3.6.3-mariadb-v3.4.9-win-v3-${{ github.run_id }}
+          restore-keys: |
+            extralibs-sqlite3-3530400-hiredis-v1.4.0-openssl-3.6.3-mariadb-v3.4.9-win-v3-
       # Windows counterpart of the Linux job's identically-named step - see
       # its comment for the overall rationale. x86_64-w64-windows-gnu (this
       # job's own native target) is built via the native MSYS2 gcc, same as
@@ -917,6 +969,7 @@ jobs:
       # file: any single library/target failing just warns and is skipped,
       # never fails the job.
       - name: Build static third-party libs for x86_64-w64-windows-gnu + linux-musl targets
+        id: extralibs
         shell: 'C:\msys64\usr\bin\bash.exe --login -eo pipefail "{0}"'
         env:
           MSYSTEM: MINGW64
@@ -924,6 +977,15 @@ jobs:
         run: |
           set -eu
           pacman -Sy --noconfirm --needed git unzip >/dev/null
+
+          # See the Linux job's identical fingerprint helper: it decides
+          # whether the save step below has anything new worth uploading.
+          mkdir -p /c/extralibs
+          fingerprint() {
+            find "$1" -type f 2>/dev/null \
+              | LC_ALL=C sort | sha256sum | cut -d' ' -f1
+          }
+          EXTRALIBS_BEFORE=$(fingerprint /c/extralibs)
 
           # need_build/need_build_openssl take the target triple as their
           # last argument (unlike this step's previous windows-gnu-only
@@ -1203,6 +1265,25 @@ jobs:
             var="SALAM_EMBED_EXTRALIBS_$(echo "$triple" | tr 'a-z-' 'A-Z_')_DIR"
             echo "${var}=C:/extralibs/$triple" >> "$GITHUB_ENV"
           done
+
+          # Fail safe towards saving: an empty fingerprint means the
+          # helper itself broke, and skipping the save on that would
+          # quietly reintroduce the very staleness this replaced.
+          EXTRALIBS_AFTER=$(fingerprint /c/extralibs)
+          if [ -n "$EXTRALIBS_AFTER" ] && [ "$EXTRALIBS_BEFORE" = "$EXTRALIBS_AFTER" ]; then
+            echo 'changed=false' >> "$GITHUB_OUTPUT"
+            echo 'static libs fully cached; skipping cache save'
+          else
+            echo 'changed=true' >> "$GITHUB_OUTPUT"
+            echo 'static libs changed; a fresh cache entry will be saved'
+          fi
+
+      - name: Save static third-party libs (sqlite3 + hiredis + openssl + mariadb, per --target=)
+        if: steps.extralibs.outputs.changed == 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: C:\extralibs
+          key: extralibs-sqlite3-3530400-hiredis-v1.4.0-openssl-3.6.3-mariadb-v3.4.9-win-v3-${{ github.run_id }}
 
       - name: Build salam.exe (embedded LLVM; best-effort LLD + mingw/musl sysroots)
         shell: 'C:\msys64\usr\bin\bash.exe --login -eo pipefail "{0}"'


### PR DESCRIPTION
Every release rebuilt sqlite3/hiredis/openssl/mariadb for the musl targets
from scratch, even though the step prints `reusing cached ...` for others.
Two separate causes, one commit each.

### The static libs cache froze on its first miss

`actions/cache` only *writes* an entry when its key **misses**. Both extralibs
caches used a single immutable key:

```yaml
key: extralibs-sqlite3-3530400-hiredis-v1.4.0-openssl-3.6.3-mariadb-v3.4.9-v2
```

So whichever partial set the very first run produced got pinned permanently.
Any run that staged only part of the targets (a musl sysroot fetch that failed,
a cross-toolchain download that 404'd) froze that state: every later run hit the
stale entry, rebuilt the missing libs from scratch, and **could not save them
back** because the key already existed. That is exactly the log pattern, where
the Windows job reuses cached openssl/mariadb for its own native target while
rebuilding sqlite3/hiredis for all four linux-musl targets it cross-builds, since
those depend on sysroots staged a step later than the entry that got frozen.

Now a restore/save split with `-${{ github.run_id }}` plus a prefix
`restore-keys`, matching the pattern every other cache in this file already
uses. Each run starts from the newest entry and can save a more complete one, so
the cache converges instead of freezing. The trailing `-` in the restore prefix
means the old frozen entries are not matched, so this cuts over cleanly with no
version bump.

### Duplicate uploads were evicting it anyway

The repo cache sits at **9.94 GB of its 10 GB budget**, and GitHub evicts LRU.
Grouping the 176 live entries by prefix:

| entry | copies | total |
|---|---|---|
| `brew-dl-ARM64-<run_id>` | 9 | 3981 MB |
| `msys2-mingw64-pkgs-<run_id>` | 8 | 2348 MB |

**6.14 GB of the 9.94 GB is redundant copies.** Both roll their key on `run_id`,
so a plain `actions/cache` stored a fresh full copy every single run of content
that changes only when package versions do. Same restore/save split, with the
save gated on a cheap fingerprint of the directory. ccache entries are left
alone: they legitimately change every run.

### Verification

`actionlint` clean, YAML parses, every `run:` block passes `bash -n`. Checked by
parsing the result that all four restore/save pairs use identical keys and paths
and that each save's `if:` names a step id that exists. The save decision was
simulated with the helper extracted from the file: unchanged tree gives
`changed=false`, a newly added target gives `changed=true`. The comparison fails
safe towards saving, since an empty fingerprint would otherwise silently
reintroduce the staleness this replaces. The macOS step uses `shasum -a 256`
rather than `sha256sum`, which macOS does not ship.

First run after merge still rebuilds everything once, because the old frozen
entries are deliberately not reused. Runs after that should print `reusing
cached` for every target.