### PR TITLE
ci: cache the bundled tcc instead of rebuilding it every run

### DIFF
--- a/.github/workflows/compiler-release.yml
+++ b/.github/workflows/compiler-release.yml
@@ -1431,15 +1431,37 @@ jobs:
       # - eight years and a win64 float-argument miscompile behind mob. It
       # installs straight into the bundle at salam-windows/tcc, the same path
       # the zip used to unpack to, so everything downstream is unchanged.
+      # The build is entirely determined by the pinned commit and the script
+      # driving it, so it is worth caching rather than repeating every run:
+      # a clone of tinycc's history plus a full compile, for a bundle that
+      # comes out byte-for-byte the same. Keyed on both files so moving the
+      # pin or changing the build invalidates it; the install prefix is a
+      # fixed path under the workspace, which matters because configure
+      # bakes it into the binary, so restoring it elsewhere would not work.
+      # The staging step below runs `tcc.exe -v` on whatever lands here, so
+      # a restored bundle still has to prove it runs.
+      - name: Restore bundled tcc
+        id: tccbundle
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: salam-windows/tcc
+          key: tcc-bundle-windows-x86_64-${{ hashFiles('tools/ci/tinycc-ref.txt', 'tools/ci/build-tcc.sh') }}-v1
       # MSYS2 rather than the `shell: bash` the staging step below uses:
       # building tcc needs gcc and make, which Git Bash does not have.
       - name: Build bundled tcc from the pinned TinyCC commit
+        if: steps.tccbundle.outputs.cache-hit != 'true'
         shell: 'C:\msys64\usr\bin\bash.exe --login -eo pipefail "{0}"'
         env:
           MSYSTEM: MINGW64
           CHERE_INVOKING: '1'
         run: |
           sh tools/ci/build-tcc.sh "$(pwd)/salam-windows/tcc"
+      - name: Save bundled tcc
+        if: steps.tccbundle.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: salam-windows/tcc
+          key: tcc-bundle-windows-x86_64-${{ hashFiles('tools/ci/tinycc-ref.txt', 'tools/ci/build-tcc.sh') }}-v1
 
       - name: Stage self-contained bundle
         shell: bash
@@ -1856,6 +1878,15 @@ jobs:
           fi
           echo "OK: salam.exe imports only Windows system DLLs."
 
+      # Same reasoning as the x86_64 bundle above, with its own key: this
+      # cross-build runs on a Linux runner and produces an i686 PE, so it
+      # must never share an entry with a native build on the same runner.
+      - name: Restore bundled tcc (i686 cross)
+        id: tccbundle
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: salam-windows-i686/tcc
+          key: tcc-bundle-windows-i686-cross-${{ hashFiles('tools/ci/tinycc-ref.txt', 'tools/ci/build-tcc.sh') }}-v1
       - name: Stage 32-bit bundle
         run: |
           set -eu
@@ -1871,9 +1902,19 @@ jobs:
           # native i686 runner to build it on. build-tcc.sh reads the target
           # name (i386-win32) back out of those two flags and builds the
           # runtime with a host-native tcc of its own - see the script.
-          CROSS_PREFIX=/tmp/llvm-mingw/bin/i686-w64-mingw32- \
-          TCC_CONFIGURE_EXTRA="--targetos=WIN32 --cpu=i386" \
-            sh tools/ci/build-tcc.sh "$(pwd)/$DIST/tcc"
+          # A tcc.exe with no libtcc1.a beside it links nothing, so both have
+          # to be there before the cached bundle counts as usable. The build
+          # is all-or-nothing and the save only runs after it succeeds, so a
+          # half-written entry should not exist; this just makes one
+          # self-heal instead of shipping a bundle that cannot compile.
+          if [ -f "$DIST/tcc/tcc.exe" ] \
+             && [ -n "$(find "$DIST/tcc" -name libtcc1.a 2>/dev/null | head -1)" ]; then
+            echo "reusing cached tcc bundle at $DIST/tcc"
+          else
+            CROSS_PREFIX=/tmp/llvm-mingw/bin/i686-w64-mingw32- \
+            TCC_CONFIGURE_EXTRA="--targetos=WIN32 --cpu=i386" \
+              sh tools/ci/build-tcc.sh "$(pwd)/$DIST/tcc"
+          fi
           file "$DIST/tcc/tcc.exe"
           cp README.md LICENSE "$DIST/" 2>/dev/null || true
           {
@@ -1906,6 +1947,12 @@ jobs:
           } > "$DIST/RUN-ME.txt"
           echo "bundle contents:"; ls -la "$DIST"
 
+      - name: Save bundled tcc (i686 cross)
+        if: steps.tccbundle.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: salam-windows-i686/tcc
+          key: tcc-bundle-windows-i686-cross-${{ hashFiles('tools/ci/tinycc-ref.txt', 'tools/ci/build-tcc.sh') }}-v1
       - name: Smoke-test the 32-bit build (format checks only - can't execute an i686 PE on this Linux host)
         run: |
           set -e


### PR DESCRIPTION
The repo already has a `setup-tcc` action that builds tcc from the pin in
`tools/ci/tinycc-ref.txt` and caches it. Four workflows use it. The two release
bundles do not: they call `tools/ci/build-tcc.sh` directly, so they clone
tinycc's full history and compile the whole thing on every single run, for
output that the pinned commit determines completely.

- `build-windows` builds it natively into `salam-windows/tcc`
- `build-windows-i686` cross-builds an i686 PE into `salam-windows-i686/tcc`

Both now restore that prefix from a cache first and only build on a miss.

### Why not just reuse the setup-tcc action

Two reasons, both of which would have introduced a bug.

**The cache key would collide.** `setup-tcc` keys on
`runner.os`/`runner.arch` plus the pin hash. `build-windows-i686` runs on
**ubuntu-latest** (there is no i686 runner to build on), exactly like the
`build-linux` job that already uses the action for a *native Linux* tcc. Same
key, different compilers: one job would silently get the other's binary. The two
keys here are explicitly distinct.

**The shell is wrong.** The Windows build must run under MSYS2, because tcc needs
gcc and make and Git Bash has neither. A composite action cannot take `shell:`
as an input, so the action could not have driven that step.

### Details worth noting

The key hashes `build-tcc.sh` alongside `tinycc-ref.txt`, so changing how tcc is
built invalidates the entry, not just moving the pin.

The cached path has to be the exact install prefix, because `configure --prefix`
bakes the path into the binary; restoring the same bundle elsewhere would not
work. Both prefixes are fixed paths under the workspace, so this holds.

The i686 build sits in the middle of the larger staging step, so instead of an
`if:` on the step it is guarded in the shell on `tcc.exe` **and** a `libtcc1.a`
existing. A tcc without its runtime links nothing, and that combination cannot
be produced here anyway (the build is all-or-nothing and the save only runs
after it succeeds), so the check exists to make a bad entry self-heal rather
than ship a bundle that cannot compile.

### Verification

`actionlint` clean, YAML parses, the staging step passes `bash -n` and `sh -n`.
Checked by parsing the result that both restore/save pairs use identical keys and
paths and that the two keys differ from each other. The guard was exercised
against real tcc install layouts: missing bundle rebuilds, complete Windows
layout (`tcc/lib/libtcc1.a`) reuses, `tcc.exe` with no runtime rebuilds, unix
layout (`tcc/libtcc1.a`) reuses.

No extra verification step was added for the x86_64 bundle: the staging step
right after it already runs `tcc.exe -v`, so a restored bundle still has to
prove it runs.