### PR TITLE
release: publish the stdlib index as a release asset

### DIFF
--- a/.github/workflows/compiler-release.yml
+++ b/.github/workflows/compiler-release.yml
@@ -2671,6 +2671,20 @@ jobs:
           [ -f ./release-linux-aarch64/salam ]    && mv ./release-linux-aarch64/salam    ./release/salam-linux-aarch64    || true
           [ -f ./release-linux-armhf/salam ]      && mv ./release-linux-armhf/salam      ./release/salam-linux-armhf      || true
           echo "release/ now contains:"; ls -la ./release
+
+      # The machine-readable std/ index the MCP server and the editor tooling
+      # read. It is committed, and mcp-server.yml fails the build when it
+      # drifts from std/, so the copy checked out here is the one that matches
+      # this tag. Publishing it per-release means consumers can pin a version
+      # instead of pointing a raw URL at a branch that keeps moving.
+      - name: Stage the stdlib index
+        run: |
+          set -eu
+          src=docs/ai/stdlib-index.json
+          [ -f "$src" ] || { echo "::error::$src is missing"; exit 1; }
+          mkdir -p ./release
+          cp "$src" "./release/salam-${VERSION}-stdlib-index.json"
+          ls -l "./release/salam-${VERSION}-stdlib-index.json"
       # - name: Post Linux release file to SERVER_VERSIONS_API
       #   env:
       #     SERVER_VERSIONS_API: ${{ secrets.SERVER_VERSIONS_API }}
@@ -2733,6 +2747,7 @@ jobs:
             # release/salam-linux-aarch64
             # release/salam-linux-armhf
             release/salam-*.zip
+            release/salam-*-stdlib-index.json
             release/salam-application-*.aab
             release/salam-application-*.apk
           )


### PR DESCRIPTION
`docs/ai/stdlib-index.json` (71 packages, ~300 KB) is committed, and
`mcp-server.yml` already fails the build when it drifts from `std/`, so the copy
checked out by the release job is by construction the one matching that tag. It
was never attached to a release, though, so anything consuming it had to point a
raw URL at a branch that keeps moving rather than pinning a version.

It now ships as `salam-<version>-stdlib-index.json`, named to match the other
assets. The staging step fails loudly if the file is missing rather than
publishing a release quietly short one asset.

Checked the file before wiring it up: `root` is the relative string `"std"` and
there are no absolute paths or usernames anywhere in it, so nothing about the
build machine leaks into a published artifact.

Simulated the asset-selection block against the real v0.3.1 filenames plus the
new one: 10 assets selected, no duplicates, and the `.json` does not collide with
the existing `salam-*.zip` glob.

### On the Android question that came with this

Worth recording, since the premise turned out not to hold: the AAB and the APK
are **already separate assets**, and have been for at least three releases.

```
v0.3.1  salam-application-v0.3.1-301.aab
        salam-application-v0.3.1-301-universal.apk
v0.3.0  salam-application-v1.0-1.aab
        salam-application-v1.0-1-universal.apk
```

The single zip is the GitHub Actions **artifact** (`salam-android-release`) on
the workflow run page. GitHub always serves artifacts as a zip, even one holding
a single file, and that is not something the workflow controls. Release assets
are raw files and are already split, so nothing changed there.

Separately: only a `-universal.apk` is produced because `android/app/build.gradle.kts`
has no `splits` block, which is correct here. The app is a WebView wrapper with
no native code, so per-ABI APKs would be byte-identical to each other. The build
step's name says "per-ABI APKs", which is a misleading leftover, but the
behaviour is right.