### PR TITLE
llvm: fix the self-hosted backend on package-shadowing locals, and lift libsalam_llvm.a out of c/

### DIFF
--- a/compiler/llvmgen/llvm_call_kinds.salam
+++ b/compiler/llvmgen/llvm_call_kinds.salam
@@ -268,7 +268,19 @@ func call_method(v &: Lv, s &: sm.Sema, a &: at.Ast, n: int, callee: int): Llv:
         ret len_of(v, s, a, n, obj)
     end
 
-    if objn.kind == at.AST_IDENTIFIER:
+    // Package-qualified call (`str.Equals(...)`). Gated on the receiver having
+    // no value type of its own, and the gate has to cover BOTH lookups below:
+    // sym_of searches the global scope and then every loaded package, so a
+    // function-local whose name matches a package's - `mut map := Vector {} as
+    // Vector<int>` in jsgen_call.salam, against std/map's `package map` -
+    // resolved to the package, and its `map.push(...)` came back as "package
+    // function 'push' not found". A package identifier carries no value type,
+    // so requiring an empty/<null> type separates the two cleanly. sema types a
+    // real value and leaves only the unresolved package case as "<null>";
+    // keying off the codegen-time locals list instead was wrong, since a local
+    // declared in an enclosing block is not always registered yet at the call
+    // site.
+    if objn.kind == at.AST_IDENTIFIER && (str.Len(ots) == 0 || str.Equals(ots, "<null>")):
         pk := sym_of(v, s, a, objn.name)
         if pk != 0 && sm.SymAt(s, pk).kind == sm.SYM_PACKAGE:
             ret call_pkg(v, s, a, n, pk, mname)
@@ -277,23 +289,14 @@ func call_method(v &: Lv, s &: sm.Sema, a &: at.Ast, n: int, callee: int): Llv:
         // is also an extern function's - std/time is `package time` and
         // declares `extern func time(...)` - can resolve to the function
         // instead, leaving `time.FormatDate(...)` reported as a method on
-        // type '<null>'. Only consulted when the receiver is not a value
-        // in scope, so a local shadowing a package name still wins.
-        // Gated on the receiver having no type of its own. sema types a
-        // real value (`map.free()` where `map` is a local HashMap, and
-        // std/map is also `package map`) and leaves only the unresolved
-        // package case as "<null>" - keying off the codegen-time locals
-        // list instead was wrong, since a local declared in an enclosing
-        // block is not always registered yet at the call site.
-        if str.Len(ots) == 0 || str.Equals(ots, "<null>"):
-            mut pi := 0
-            until pi < sm.PackageCount(s):
-                cand := sm.PackageAt(s, pi)
-                if cand != 0 && str.Equals(sm.SymAt(s, cand).pkgname, objn.name):
-                    ret call_pkg(v, s, a, n, cand, mname)
-                end
-                pi += 1
+        // type '<null>'.
+        mut pi := 0
+        until pi < sm.PackageCount(s):
+            cand := sm.PackageAt(s, pi)
+            if cand != 0 && str.Equals(sm.SymAt(s, cand).pkgname, objn.name):
+                ret call_pkg(v, s, a, n, cand, mname)
             end
+            pi += 1
         end
     end
 

--- a/std/llvm/native/build.sh
+++ b/std/llvm/native/build.sh
@@ -1,0 +1,133 @@
+#!/bin/sh
+# Builds libsalam_llvm.a: the six native shim objects merged with every static
+# LLVM (and, when available, LLD) archive on the host, so `link static
+# "salam_llvm"` in std/llvm/llvm.salam resolves without llvm-*-dev installed
+# on the consuming machine.
+#
+# This used to be c/Makefile's `libsalam-llvm` target. It lives here now, next
+# to the sources it compiles, because the self-hosted compiler needs the same
+# archive and the C compiler that used to build it is gone.
+#
+# Usage:
+#   std/llvm/native/build.sh [--out DIR] [--llvm-config PROG]
+#
+# Env:
+#   CC, CXX, AR         host tools (default: cc, c++, llvm-ar or ar)
+#   LLD_EXTRA_LIBDIR    extra directory to search for liblld*.a
+#   WITH_LLD            1 to demand in-process LLD, 0 to stub it out.
+#                       Default: autodetected from whether liblldCommon.a
+#                       is findable.
+
+set -eu
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+OUT=$(pwd)
+LLVM_CONFIG=${LLVM_CONFIG:-llvm-config}
+
+while [ $# -gt 0 ]; do
+    case $1 in
+    --out) OUT=$2; shift 2 ;;
+    --llvm-config) LLVM_CONFIG=$2; shift 2 ;;
+    -h | --help) sed -n '2,24p' "$0"; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+command -v "$LLVM_CONFIG" >/dev/null 2>&1 || {
+    echo "error: $LLVM_CONFIG not found; install LLVM development files or pass" >&2
+    echo "       --llvm-config /path/to/llvm-config-NN" >&2
+    exit 1
+}
+
+: "${CC:=cc}"
+: "${CXX:=c++}"
+LIBDIR=$($LLVM_CONFIG --libdir 2>/dev/null || true)
+BINDIR=$($LLVM_CONFIG --bindir 2>/dev/null || true)
+: "${AR:=$(command -v "$BINDIR/llvm-ar" 2>/dev/null || command -v llvm-ar 2>/dev/null || command -v ar)}"
+SEARCH="$LIBDIR ${LLD_EXTRA_LIBDIR:-}"
+
+# LLD is a separate package on most hosts, and its archives are the only
+# thing that can be absorbed here (a .dylib/.so cannot). Without them the
+# stub keeps std/llvm resolving and the compiler links through the host cc.
+find_lib() {
+    for d in $SEARCH; do
+        [ -f "$d/$1" ] && { printf '%s\n' "$d/$1"; return 0; }
+    done
+    return 1
+}
+if [ -z "${WITH_LLD:-}" ]; then
+    if find_lib liblldCommon.a >/dev/null 2>&1; then WITH_LLD=1; else WITH_LLD=0; fi
+fi
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT INT TERM
+
+echo "llvm-config : $LLVM_CONFIG ($($LLVM_CONFIG --version))"
+echo "in-process LLD : $([ "$WITH_LLD" = 1 ] && echo yes || echo 'no (stubbed)')"
+
+# -DSALAM_HAVE_LLVM is what makes orc_call.c define the five
+# salam_llvm_init_all_* wrappers at all; without it the file compiles to
+# just salam_orc_call_main and std/llvm fails to link on the five macros
+# LLVM only publishes as macros. The include path is for llvm-c/*.h.
+LLVM_INC=$($LLVM_CONFIG --includedir 2>/dev/null)
+CPPDEFS="-DSALAM_HAVE_LLVM -I$LLVM_INC"
+[ "$WITH_LLD" = 1 ] && CPPDEFS="$CPPDEFS -DSALAM_HAVE_LLD"
+
+SHIMS=""
+# shellcheck disable=SC2086
+$CC -O2 -I"$HERE" $CPPDEFS -c "$HERE/orc_call.c" -o "$WORK/orc_call.o"
+SHIMS="$SHIMS $WORK/orc_call.o"
+
+if [ "$WITH_LLD" = 1 ]; then
+    # shellcheck disable=SC2046
+    $CXX -O2 -I"$HERE" $CPPDEFS $($LLVM_CONFIG --cxxflags) -c "$HERE/lld_link.cc" -o "$WORK/lld_link.o"
+    SHIMS="$SHIMS $WORK/lld_link.o"
+    LLD_LIBS="lldMinGW lldELF lldCOFF lldMachO lldWasm lldCommon"
+else
+    # shellcheck disable=SC2086
+    $CC -O2 -I"$HERE" $CPPDEFS -c "$HERE/lld_stub.c" -o "$WORK/lld_stub.o"
+    SHIMS="$SHIMS $WORK/lld_stub.o"
+    LLD_LIBS=""
+fi
+
+# MSYS2 only; see the file's own comment for the __imp_ story.
+case "$(uname -s 2>/dev/null || echo unknown)" in
+MINGW* | MSYS* | CYGWIN*)
+    $CC -c "$HERE/win_lld_demangle_shim.S" -o "$WORK/win_shim.o"
+    SHIMS="$SHIMS $WORK/win_shim.o"
+    ;;
+esac
+
+MRI=$WORK/mri
+mkdir -p "$OUT"
+: > "$MRI"
+echo "create $OUT/libsalam_llvm.a" >> "$MRI"
+for o in $SHIMS; do echo "addmod $o" >> "$MRI"; done
+
+n=0
+missing=
+for l in $($LLVM_CONFIG --link-static --libs all 2>/dev/null) $(for x in $LLD_LIBS; do echo "-l$x"; done); do
+    case "$l" in -l*) nm="lib${l#-l}.a" ;; *) continue ;; esac
+    if a=$(find_lib "$nm"); then
+        echo "addlib $a" >> "$MRI"
+        n=$((n + 1))
+    else
+        case "$nm" in liblld*) missing="$missing $nm" ;; esac
+    fi
+done
+if [ -n "$missing" ]; then
+    echo "error: lld archives not found in [$SEARCH]:$missing" >&2
+    echo "       lld is a separate package on some hosts (Homebrew's lld formula," >&2
+    echo "       Debian's liblld-<ver>-dev). Install it, point LLD_EXTRA_LIBDIR at" >&2
+    echo "       the directory holding liblldCommon.a, or pass WITH_LLD=0." >&2
+    exit 1
+fi
+printf 'save\nend\n' >> "$MRI"
+
+echo "merging $n LLVM/lld archives + salam shims -> $OUT/libsalam_llvm.a"
+rm -f "$OUT/libsalam_llvm.a"
+"$AR" -M < "$MRI"
+
+echo "Built $OUT/libsalam_llvm.a"
+echo "  std/llvm then links with: link static \"salam_llvm\""
+echo "  plus system libs: $($LLVM_CONFIG --system-libs 2>/dev/null) -lstdc++"


### PR DESCRIPTION
Groundwork for deleting `c/`. Two things that had to be true first, plus an
honest account of what still is not.

## The self-hosted LLVM backend could not build the compiler

Bootstrapping with in-process LLVM, stage 3 hit seven errors in
`compiler/jsgen/jsgen_call.salam` and silently fell back to the C backend:

```
LLVM backend (line 370): package function 'free' not found
LLVM backend (line 379): package function 'push' not found
LLVM backend (line 422): package function 'get' not found
```

That file has `mut map := Vector {} as Vector<int>`, and `std/map` is
`package map`. `sym_of` searches the global scope and then every loaded package,
so the local lost to the package and its method calls were emitted as package
calls.

The C backend already fixed this — its comment names this exact case — and the
fix was never carried over. The gate that separates the two (a package
identifier carries no value type, a local does) was present in the self-hosted
version but guarded only the *second* of the two lookups. It now guards both, as
the C does.

Minimal reproducer, no import needed since the collision is with a package name
that merely exists:

```salam
package main
func main:
    mut map := Vector {} as Vector<int>
    map.push(5)
    println map.get(0), map.len()
    map.free()
end
```

Before: self-hosted C backend fine, self-hosted LLVM backend
`package function 'push' not found`, C compiler's LLVM backend fine. After: all
three print `11 1`.

## libsalam_llvm.a no longer needs c/Makefile

`std/llvm/native/build.sh` is the `libsalam-llvm` target ported to a standalone
script, living next to the sources it compiles. It merges the shim objects with
every static LLVM/LLD archive on the host via the same `ar -M` MRI script.

One thing that bit and is worth recording: `-DSALAM_HAVE_LLVM` is what makes
`orc_call.c` define the five `salam_llvm_init_all_*` wrappers at all. Without it
the file still compiles, to just `salam_orc_call_main`, and the archive comes out
looking fine while `std/llvm` fails to link on the five macros LLVM only
publishes as macros. Verified by symbol: all eight shim symbols are in the
archive, across 210 merged LLVM archives.

## Verified

- Bootstrap from the **published v0.3.1 release** as seed, no `c/` involved:
  stage1 → stage2 → stage3 all build. `SEED_MIN` is 0.3.1 and that is the current
  release, so the seed chain stands on its own.
- The fixpoint warning is benign: stage2 and stage3 differ in exactly 24 bytes —
  the 20-byte GNU build-id and a 4-byte build **timestamp** in `.rodata`
  (`14:49:48` vs `14:50:12`). Everything else is byte-identical.
- Self-hosted suite: 22 of 23 files clean. `semantic_test.salam`'s 4 failures are
  the same 4 unmodified `main` reports.
- The LLVM self-host gate (C compiler builds all of `compiler/` with
  `--backend=llvm`) still passes, 0 errors.

## Not done, and why c/ is still here

I did not delete `c/` in this PR, because the condition you set — the self-hosted
build being fully working with LLVM — is not met yet:

1. **The release still builds every shipped binary with `make -C c
   self-contained`.** Deleting `c/` before that is replaced leaves no way to ship.
2. **The self-hosted LLVM link path does not complete on this machine.** In-process
   lld cannot find `-lz -lzstd -lxml2 -lstdc++`, and a stage-2 host link leaves
   `LLVMOrcLLJITMangleAndIntern` undefined even though the symbol is present in
   the archive — which points at link order or grouping across the 210 merged
   archives, not a missing library. This may be local (LLD headers are also
   absent here) but I have not proven it is.
3. **The embedded-sysroot build step still does not exist** for self-host;
   `MaterializeSysroot` remains uncalled.

Those are the three things left before `c/` can go.