### PR TITLE
fix the release jobs the c/ removal left broken

### DIFF
--- a/.github/actions/setup-salam/action.yml
+++ b/.github/actions/setup-salam/action.yml
@@ -88,21 +88,40 @@ runs:
         os="$RUNNER_OS"
         arch="$RUNNER_ARCH"
 
+        # `slug` is the platform's piece of the asset name; the full name is
+        # resolved below. No release has ever published the "-minimal" variant
+        # this used to ask for by name, so every arm64/armhf/i686 lookup 404'd -
+        # which is how the aarch64 release job ended up unable to install a seed.
         case "${os}-${arch}" in
-          Linux-X64)     asset="salam-${version}-linux.zip";                    dist="salam-linux";        bin="salam" ;;
-          Linux-ARM64)   asset="salam-${version}-linux-aarch64-minimal.zip";    dist="salam-linux-aarch64"; bin="salam" ;;
-          Linux-ARM)     asset="salam-${version}-linux-armhf-minimal.zip";      dist="salam-linux-armhf";   bin="salam" ;;
-          Linux-X86)     asset="salam-${version}-linux-i686-minimal.zip";       dist="salam-linux-i686";    bin="salam" ;;
-          macOS-*)       asset="salam-${version}-mac.zip";                      dist="salam-mac";           bin="salam" ;;
-          Windows-X64)   asset="salam-${version}-windows.zip";                  dist="salam-windows";       bin="salam.exe" ;;
-          Windows-X86)   asset="salam-${version}-windows-i686-minimal.zip";     dist="salam-windows-i686";  bin="salam.exe" ;;
+          Linux-X64)     slug="linux";         dist="salam-linux";         bin="salam" ;;
+          Linux-ARM64)   slug="linux-aarch64"; dist="salam-linux-aarch64"; bin="salam" ;;
+          Linux-ARM)     slug="linux-armhf";   dist="salam-linux-armhf";   bin="salam" ;;
+          Linux-X86)     slug="linux-i686";    dist="salam-linux-i686";    bin="salam" ;;
+          macOS-*)       slug="mac";           dist="salam-mac";           bin="salam" ;;
+          Windows-X64)   slug="windows";       dist="salam-windows";       bin="salam.exe" ;;
+          Windows-X86)   slug="windows-i686";  dist="salam-windows-i686";  bin="salam.exe" ;;
           *)
             echo "::error::Unsupported runner platform ${os}-${arch}. Salam releases cover Linux (x64/arm64/armhf/i686), macOS, and Windows (x64/i686)." >&2
             exit 1
             ;;
         esac
 
+        # Prefer the plain archive; fall back to a "-minimal" one should a
+        # future release start publishing those. Whichever actually exists on
+        # the tag decides, rather than a name hardcoded here.
+        asset="salam-${version}-${slug}.zip"
         url="https://github.com/${repo}/releases/download/${tag}/${asset}"
+        if ! curl -fsIL --retry 2 -o /dev/null "$url"; then
+          alt="salam-${version}-${slug}-minimal.zip"
+          alt_url="https://github.com/${repo}/releases/download/${tag}/${alt}"
+          if curl -fsIL --retry 2 -o /dev/null "$alt_url"; then
+            asset=$alt
+            url=$alt_url
+          else
+            echo "::error::Neither ${asset} nor ${alt} exists on ${tag}." >&2
+            exit 1
+          fi
+        fi
 
         raw="${RUNNER_TOOL_CACHE:-$HOME}/salam/${version}/${arch}"
         if command -v cygpath >/dev/null 2>&1; then

--- a/.github/workflows/compiler-release.yml
+++ b/.github/workflows/compiler-release.yml
@@ -1383,6 +1383,7 @@ jobs:
           key: extralibs-sqlite3-3530400-hiredis-v1.4.0-openssl-3.6.3-mariadb-v3.4.9-win-v3-${{ github.run_id }}
 
       - name: Install a seed compiler
+        id: seed
         uses: ./.github/actions/setup-salam
 
       - name: Build salam.exe (embedded LLVM; best-effort LLD + mingw/musl sysroots)
@@ -1433,7 +1434,12 @@ jobs:
             --extralibs-aarch64-musl "${SALAM_EMBED_EXTRALIBS_AARCH64_LINUX_MUSL_DIR:-}" \
             --extralibs-i686-musl "${SALAM_EMBED_EXTRALIBS_I686_LINUX_MUSL_DIR:-}" \
             --extralibs-arm-musl "${SALAM_EMBED_EXTRALIBS_ARM_LINUX_MUSLEABIHF_DIR:-}"
+          # --seed by path, not through PATH: this step runs under MSYS2 bash,
+          # and the Windows-style directory setup-salam appends to GITHUB_PATH
+          # is not something an MSYS shell resolves, so `command -v salam`
+          # found nothing and the build stopped with "no seed compiler".
           sh tools/bash/build-selfhost.sh \
+            --seed="$(cygpath -u '${{ steps.seed.outputs.salam }}')" \
             --llvm="$GITHUB_WORKSPACE" --embed="$GITHUB_WORKSPACE" \
             --output="$GITHUB_WORKSPACE/salam.exe"
           if [ -n "$MINGW_ARG" ]; then

--- a/.github/workflows/compiler-release.yml
+++ b/.github/workflows/compiler-release.yml
@@ -1434,6 +1434,16 @@ jobs:
             --extralibs-aarch64-musl "${SALAM_EMBED_EXTRALIBS_AARCH64_LINUX_MUSL_DIR:-}" \
             --extralibs-i686-musl "${SALAM_EMBED_EXTRALIBS_I686_LINUX_MUSL_DIR:-}" \
             --extralibs-arm-musl "${SALAM_EMBED_EXTRALIBS_ARM_LINUX_MUSLEABIHF_DIR:-}"
+          # The old make line passed EXTRA_LDFLAGS="-static -static-libgcc
+          # -static-libstdc++", and dropping them is what produced
+          # "duplicate section .rdata$_ZTSSt9exception has different size":
+          # the merged LLVM archive and MSYS2's libstdc++ disagree about the
+          # same comdat unless gcc supplies its own copy. There is no
+          # --ldflags on the driver, so they ride in on a cc wrapper.
+          printf '#!/bin/sh\nexec gcc "$@" -static -static-libgcc -static-libstdc++\n' \
+            > /tmp/cc-static
+          chmod +x /tmp/cc-static
+
           # --seed by path, not through PATH: this step runs under MSYS2 bash,
           # and the Windows-style directory setup-salam appends to GITHUB_PATH
           # is not something an MSYS shell resolves, so `command -v salam`
@@ -1441,7 +1451,8 @@ jobs:
           sh tools/bash/build-selfhost.sh \
             --seed="$(cygpath -u '${{ steps.seed.outputs.salam }}')" \
             --llvm="$GITHUB_WORKSPACE" --embed="$GITHUB_WORKSPACE" \
-            --output="$GITHUB_WORKSPACE/salam.exe"
+            --output="$GITHUB_WORKSPACE/salam.exe" \
+            -- --cc=/tmp/cc-static
           if [ -n "$MINGW_ARG" ]; then
             echo "SELF_CONTAINED=1" >> "$GITHUB_ENV"
           else
@@ -1892,6 +1903,17 @@ jobs:
           # Without it the link came back with every Win32 import undefined
           # (_GetStdHandle, _EnterCriticalSection, ...).
           export SALAM_SYSROOTS=/tmp/llvm-mingw
+          # llvm-mingw carries compiler-rt where a gcc-built mingw carries
+          # libgcc, so -lgcc/-lgcc_eh find nothing and the link stops there.
+          # Point the two names at what this toolchain actually has: the
+          # builtins archive for libgcc, and an empty one for libgcc_eh, since
+          # unwinding here comes from libunwind rather than libgcc_eh.
+          mgw_lib=/tmp/llvm-mingw/i686-w64-mingw32/lib
+          if [ -d "$mgw_lib" ]; then
+            rt=$(find /tmp/llvm-mingw -name 'libclang_rt.builtins-i386.a' 2>/dev/null | head -1)
+            [ -n "$rt" ] && [ ! -f "$mgw_lib/libgcc.a" ] && cp "$rt" "$mgw_lib/libgcc.a"
+            [ -f "$mgw_lib/libgcc_eh.a" ] || "$TC/llvm-ar" rcs "$mgw_lib/libgcc_eh.a"
+          fi
           if sh tools/bash/build-selfhost.sh --llvm="$GITHUB_WORKSPACE" \
             --output="$GITHUB_WORKSPACE/salam.exe" \
             -- --target=i686-w64-windows-gnu; then

--- a/.github/workflows/compiler-release.yml
+++ b/.github/workflows/compiler-release.yml
@@ -1746,6 +1746,9 @@ jobs:
     name: Build Salam for Windows (32-bit / i686, cross-compiled static LLVM+LLD)
     runs-on: ubuntu-latest
     continue-on-error: true
+    # The cross build is driven by the Linux binary this run just produced,
+    # not by the released seed - see "Use this run's Linux salam" below.
+    needs: build-linux
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1847,8 +1850,21 @@ jobs:
           restore-keys: |
             ccache-win-i686-v3-
 
-      - name: Install a seed compiler
-        uses: ./.github/actions/setup-salam
+      # The compiler that emits the i686 Windows code has to be one built
+      # from THIS commit, not the last release: a published seed carries the
+      # codegen it was released with, so any fix on the way to a working
+      # 32-bit Windows binary (the -alternatename aliases that resolve the
+      # stdcall-decorated Win32 imports, for one) would sit unused until the
+      # next release, and the job would keep failing for a bug already fixed
+      # in the tree. build-linux has already produced exactly such a
+      # compiler, with LLVM and LLD embedded, so use it directly.
+      - name: Use this run's Linux salam as the cross-compiler
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: salam-linux
+          path: /tmp/host-salam
+      - name: Make it executable
+        run: chmod +x /tmp/host-salam/salam
 
       - name: Build 32-bit salam.exe (cross-compiled, embedded static LLVM+LLD, best-effort)
         run: |
@@ -1928,7 +1944,8 @@ jobs:
               "$TC/llvm-ar" rcs "$mgw_lib/libgcc_eh.a"
             fi
           fi
-          if sh tools/bash/build-selfhost.sh --llvm="$GITHUB_WORKSPACE" \
+          if sh tools/bash/build-selfhost.sh --seed=/tmp/host-salam/salam \
+            --llvm="$GITHUB_WORKSPACE" \
             --output="$GITHUB_WORKSPACE/salam.exe" \
             -- --target=i686-w64-windows-gnu \
             --libpath="$mgw_lib"; then
@@ -1936,7 +1953,7 @@ jobs:
             echo "Built cross-compiled salam.exe with embedded LLVM+LLD."
           else
             echo "::warning::cross build with LLVM failed; retrying without it."
-            sh tools/bash/build-selfhost.sh \
+            sh tools/bash/build-selfhost.sh --seed=/tmp/host-salam/salam \
               --output="$GITHUB_WORKSPACE/salam.exe" \
               -- --target=i686-w64-windows-gnu --libpath="$mgw_lib"
             echo "SELF_CONTAINED=0" >> "$GITHUB_ENV"

--- a/.github/workflows/compiler-release.yml
+++ b/.github/workflows/compiler-release.yml
@@ -805,7 +805,11 @@ jobs:
           # skip every target anyway. LLVM only.
           sh std/llvm/native/build.sh \
             --llvm-config "$LLVM_PREFIX/bin/llvm-config" --out "$GITHUB_WORKSPACE"
-          sh tools/bash/build-selfhost.sh --llvm="$GITHUB_WORKSPACE"
+          # Homebrew's zstd/zlib sit outside the default link path, and the
+          # merged archive references them; the old Makefile passed the same
+          # directory as EXTRA_LDFLAGS.
+          sh tools/bash/build-selfhost.sh --llvm="$GITHUB_WORKSPACE" \
+            -- --libpath="$(brew --prefix)/lib"
           ./salam version
       # The Linux and Windows jobs already refuse to ship a binary that
       # imports a third-party library; macOS had no such gate, and 0.2.7

--- a/.github/workflows/compiler-release.yml
+++ b/.github/workflows/compiler-release.yml
@@ -805,11 +805,23 @@ jobs:
           # skip every target anyway. LLVM only.
           sh std/llvm/native/build.sh \
             --llvm-config "$LLVM_PREFIX/bin/llvm-config" --out "$GITHUB_WORKSPACE"
-          # Homebrew's zstd/zlib sit outside the default link path, and the
-          # merged archive references them; the old Makefile passed the same
-          # directory as EXTRA_LDFLAGS.
+          # zstd is the one library neither the SDK nor the default search
+          # path provides; it comes from Homebrew. Pointing -L at brew's lib
+          # finds the *dylib*, and a release that links /opt/homebrew/... dies
+          # on any Mac without that exact formula - which the self-containment
+          # check below is there to catch. Apple's linker has no -Bstatic, and
+          # picks the .dylib whenever both sit in one directory, so the archive
+          # gets a directory of its own instead. Same thing c/Makefile did with
+          # its MACOS_ZSTD_A.
+          mkdir -p "$GITHUB_WORKSPACE/maclibs"
+          zstd_a="$(brew --prefix zstd)/lib/libzstd.a"
+          if [ -f "$zstd_a" ]; then
+            cp "$zstd_a" "$GITHUB_WORKSPACE/maclibs/"
+          else
+            echo "::warning::no static libzstd in $(brew --prefix zstd)/lib; the link will fall back to the dylib"
+          fi
           sh tools/bash/build-selfhost.sh --llvm="$GITHUB_WORKSPACE" \
-            -- --libpath="$(brew --prefix)/lib"
+            -- --libpath="$GITHUB_WORKSPACE/maclibs" --libpath="$(brew --prefix)/lib"
           ./salam version
       # The Linux and Windows jobs already refuse to ship a binary that
       # imports a third-party library; macOS had no such gate, and 0.2.7
@@ -2041,7 +2053,7 @@ jobs:
           # so 21 is the newest release that still targets 32-bit hosts at
           # all; 22+ tracks amd64/arm64 only (see the 64-bit jobs above).
           docker run --rm --platform=linux/386 \
-            -v "$PWD:/work" -w /work/c \
+            -v "$PWD:/work" -w /work \
             -v /tmp/ccache-i686:/root/.ccache \
             -e CCACHE_DIR=/root/.ccache \
             i386/debian:sid bash -euxc '
@@ -2202,7 +2214,7 @@ jobs:
           # 32-bit hosts at all (LLVM stopped shipping 32-bit Windows
           # installers at v22: github.com/ScoopInstaller/Main/issues/7685).
           docker run --rm --platform=linux/arm/v7 \
-            -v "$PWD:/work" -w /work/c \
+            -v "$PWD:/work" -w /work \
             -v /tmp/ccache-armhf:/root/.ccache \
             -e CCACHE_DIR=/root/.ccache \
             arm32v7/debian:sid bash -euxc '

--- a/.github/workflows/compiler-release.yml
+++ b/.github/workflows/compiler-release.yml
@@ -846,7 +846,7 @@ jobs:
             echo ""
             echo "These are Homebrew Cellar paths, usually versioned. dyld aborts at"
             echo "startup on any machine without that exact formula version installed."
-            echo "Either drop the library (see the -lz3 note in c/Makefile) or link its"
+            echo "Either drop the library, or link its"
             echo "static archive instead of the dylib."
             exit 1
           fi

--- a/.github/workflows/compiler-release.yml
+++ b/.github/workflows/compiler-release.yml
@@ -2022,6 +2022,13 @@ jobs:
           key: ccache-linux-i686-v2-${{ github.run_id }}
           restore-keys: |
             ccache-linux-i686-v2-
+      # setup-salam installs the runner's own architecture, which is the
+      # wrong one for a compile that happens inside a foreign-arch
+      # container. This puts the matching release beside the checkout so
+      # the container can use it as its seed.
+      - name: Fetch a seed compiler for the container
+        run: sh tools/bash/fetch-seed.sh --slug linux-i686 --out "$GITHUB_WORKSPACE/seed"
+
       - name: Build + smoke-test inside an i386/debian container (native - no QEMU needed for i386 on amd64)
         run: |
           set -eu
@@ -2071,18 +2078,14 @@ jobs:
               ccache --max-size=300M >/dev/null 2>&1 || true
               MUSL_SR=/work/sysroots/x86_64-linux-musl
               MINGW_SR=/work/sysroots/x86_64-w64-mingw32
-              if make -j"$(nproc)" \
-                   WITH_LLVM=1 WITH_LLD=1 LLVM_LINK_STATIC=1 \
-                   LLVM_CONFIG=llvm-config-21 CC="ccache gcc" CXX="ccache g++" \
-                   SALAM_EMBED_MUSL_DIR="$MUSL_SR" SALAM_EMBED_MINGW_DIR="$MINGW_SR"; then
-                echo 1 > /work/.self_contained
-              else
-                echo "::warning::self-contained (LLD) i686 build failed; falling back to embedded-LLVM-only."
-                make clean
-                make -j"$(nproc)" WITH_LLVM=1 LLVM_LINK_STATIC=1 LLVM_CONFIG=llvm-config-21 CC="ccache gcc"
-                echo 0 > /work/.self_contained
-              fi
-              ccache --show-stats 2>/dev/null | head -5 || true
+              sh std/llvm/native/build.sh --llvm-config llvm-config-21 --out /work
+              sh tools/bash/build-embed.sh --out /work \
+                --musl-x86_64 "$MUSL_SR" --mingw-x86_64 "$MINGW_SR"
+              # The seed runs in here, not on the host, so it has to be built for
+              # the same architecture as this container - fetched by the step above.
+              sh tools/bash/build-selfhost.sh --seed=/work/seed/salam \
+                --llvm=/work --embed=/work --output=/work/salam
+              echo 1 > /work/.self_contained
               file /work/salam
               /work/salam version
               export SALAM_STD=/work/std
@@ -2180,6 +2183,13 @@ jobs:
           key: ccache-linux-armhf-v2-${{ github.run_id }}
           restore-keys: |
             ccache-linux-armhf-v2-
+      # setup-salam installs the runner's own architecture, which is the
+      # wrong one for a compile that happens inside a foreign-arch
+      # container. This puts the matching release beside the checkout so
+      # the container can use it as its seed.
+      - name: Fetch a seed compiler for the container
+        run: sh tools/bash/fetch-seed.sh --slug linux-armhf --out "$GITHUB_WORKSPACE/seed"
+
       - name: Build + smoke-test inside an arm32v7/debian container (QEMU-emulated compile - slower)
         run: |
           set -eu
@@ -2209,18 +2219,14 @@ jobs:
               ccache --max-size=300M >/dev/null 2>&1 || true
               MUSL_SR=/work/sysroots/x86_64-linux-musl
               MINGW_SR=/work/sysroots/x86_64-w64-mingw32
-              if make -j"$(nproc)" \
-                   WITH_LLVM=1 WITH_LLD=1 LLVM_LINK_STATIC=1 \
-                   LLVM_CONFIG=llvm-config-21 CC="ccache gcc" CXX="ccache g++" \
-                   SALAM_EMBED_MUSL_DIR="$MUSL_SR" SALAM_EMBED_MINGW_DIR="$MINGW_SR"; then
-                echo 1 > /work/.self_contained
-              else
-                echo "::warning::self-contained (LLD) armhf build failed; falling back to embedded-LLVM-only."
-                make clean
-                make -j"$(nproc)" WITH_LLVM=1 LLVM_LINK_STATIC=1 LLVM_CONFIG=llvm-config-21 CC="ccache gcc"
-                echo 0 > /work/.self_contained
-              fi
-              ccache --show-stats 2>/dev/null | head -5 || true
+              sh std/llvm/native/build.sh --llvm-config llvm-config-21 --out /work
+              sh tools/bash/build-embed.sh --out /work \
+                --musl-x86_64 "$MUSL_SR" --mingw-x86_64 "$MINGW_SR"
+              # The seed runs in here, not on the host, so it has to be built for
+              # the same architecture as this container - fetched by the step above.
+              sh tools/bash/build-selfhost.sh --seed=/work/seed/salam \
+                --llvm=/work --embed=/work --output=/work/salam
+              echo 1 > /work/.self_contained
               file /work/salam
               /work/salam version
               export SALAM_STD=/work/std

--- a/.github/workflows/compiler-release.yml
+++ b/.github/workflows/compiler-release.yml
@@ -815,13 +815,14 @@ jobs:
           # its MACOS_ZSTD_A.
           mkdir -p "$GITHUB_WORKSPACE/maclibs"
           zstd_a="$(brew --prefix zstd)/lib/libzstd.a"
-          if [ -f "$zstd_a" ]; then
-            cp "$zstd_a" "$GITHUB_WORKSPACE/maclibs/"
-          else
-            echo "::warning::no static libzstd in $(brew --prefix zstd)/lib; the link will fall back to the dylib"
-          fi
+          [ -f "$zstd_a" ] || {
+            echo "::error::no static libzstd at $zstd_a - the only other thing -lzstd" >&2
+            echo "  could resolve to is the dylib, which the check below rejects." >&2
+            exit 1
+          }
+          cp "$zstd_a" "$GITHUB_WORKSPACE/maclibs/"
           sh tools/bash/build-selfhost.sh --llvm="$GITHUB_WORKSPACE" \
-            -- --libpath="$GITHUB_WORKSPACE/maclibs" --libpath="$(brew --prefix)/lib"
+            -- --libpath="$GITHUB_WORKSPACE/maclibs"
           ./salam version
       # The Linux and Windows jobs already refuse to ship a binary that
       # imports a third-party library; macOS had no such gate, and 0.2.7
@@ -1879,6 +1880,12 @@ jobs:
             sh std/llvm/native/build.sh --llvm-config /tmp/fake-llvm-config \
             --out "$GITHUB_WORKSPACE"
 
+          # llvm-mingw lays its target libraries out as <root>/<triple>/lib,
+          # which is exactly the shape $SALAM_SYSROOTS is searched with, so
+          # pointing at the root is enough to resolve kernel32 and friends.
+          # Without it the link came back with every Win32 import undefined
+          # (_GetStdHandle, _EnterCriticalSection, ...).
+          export SALAM_SYSROOTS=/tmp/llvm-mingw
           if sh tools/bash/build-selfhost.sh --llvm="$GITHUB_WORKSPACE" \
             --output="$GITHUB_WORKSPACE/salam.exe" \
             -- --target=i686-w64-windows-gnu; then

--- a/.github/workflows/compiler-release.yml
+++ b/.github/workflows/compiler-release.yml
@@ -1440,9 +1440,13 @@ jobs:
           # the merged LLVM archive and MSYS2's libstdc++ disagree about the
           # same comdat unless gcc supplies its own copy. There is no
           # --ldflags on the driver, so they ride in on a cc wrapper.
-          printf '#!/bin/sh\nexec gcc "$@" -static -static-libgcc -static-libstdc++\n' \
-            > /tmp/cc-static
-          chmod +x /tmp/cc-static
+          # A .bat, not a shell script: the driver spawns the C compiler as a
+          # native Windows command, and cmd cannot run a shebang. A shell
+          # wrapper came back as "'C:/msys64/tmp/cc-static' is not recognized
+          # as an internal or external command". c/Makefile's own musl wrapper
+          # emitted a .bat twin for exactly this reason.
+          printf '@echo off\r\ngcc %%* -static -static-libgcc -static-libstdc++\r\n' \
+            > /tmp/cc-static.bat
 
           # --seed by path, not through PATH: this step runs under MSYS2 bash,
           # and the Windows-style directory setup-salam appends to GITHUB_PATH
@@ -1452,7 +1456,7 @@ jobs:
             --seed="$(cygpath -u '${{ steps.seed.outputs.salam }}')" \
             --llvm="$GITHUB_WORKSPACE" --embed="$GITHUB_WORKSPACE" \
             --output="$GITHUB_WORKSPACE/salam.exe" \
-            -- --cc=/tmp/cc-static
+            -- --cc="$(cygpath -m /tmp/cc-static.bat)"
           if [ -n "$MINGW_ARG" ]; then
             echo "SELF_CONTAINED=1" >> "$GITHUB_ENV"
           else
@@ -1908,22 +1912,33 @@ jobs:
           # Point the two names at what this toolchain actually has: the
           # builtins archive for libgcc, and an empty one for libgcc_eh, since
           # unwinding here comes from libunwind rather than libgcc_eh.
+          # The sysroot is found by name, but its import libraries (kernel32,
+          # user32, ...) still have to be on the link's -L list, which is why
+          # _GetFileType and friends came back undefined even with the sysroot
+          # detected.
           mgw_lib=/tmp/llvm-mingw/i686-w64-mingw32/lib
           if [ -d "$mgw_lib" ]; then
             rt=$(find /tmp/llvm-mingw -name 'libclang_rt.builtins-i386.a' 2>/dev/null | head -1)
-            [ -n "$rt" ] && [ ! -f "$mgw_lib/libgcc.a" ] && cp "$rt" "$mgw_lib/libgcc.a"
-            [ -f "$mgw_lib/libgcc_eh.a" ] || "$TC/llvm-ar" rcs "$mgw_lib/libgcc_eh.a"
+            # Written as ifs, not && chains: under `set -e` a chain whose first
+            # test is false takes the whole step down with it.
+            if [ -n "$rt" ] && [ ! -f "$mgw_lib/libgcc.a" ]; then
+              cp "$rt" "$mgw_lib/libgcc.a"
+            fi
+            if [ ! -f "$mgw_lib/libgcc_eh.a" ]; then
+              "$TC/llvm-ar" rcs "$mgw_lib/libgcc_eh.a"
+            fi
           fi
           if sh tools/bash/build-selfhost.sh --llvm="$GITHUB_WORKSPACE" \
             --output="$GITHUB_WORKSPACE/salam.exe" \
-            -- --target=i686-w64-windows-gnu; then
+            -- --target=i686-w64-windows-gnu \
+            --libpath="$mgw_lib"; then
             echo "SELF_CONTAINED=1" >> "$GITHUB_ENV"
             echo "Built cross-compiled salam.exe with embedded LLVM+LLD."
           else
             echo "::warning::cross build with LLVM failed; retrying without it."
             sh tools/bash/build-selfhost.sh \
               --output="$GITHUB_WORKSPACE/salam.exe" \
-              -- --target=i686-w64-windows-gnu
+              -- --target=i686-w64-windows-gnu --libpath="$mgw_lib"
             echo "SELF_CONTAINED=0" >> "$GITHUB_ENV"
           fi
           file salam.exe

--- a/.github/workflows/editor-playground-build.yml
+++ b/.github/workflows/editor-playground-build.yml
@@ -19,6 +19,11 @@ jobs:
         with:
           persist-credentials: false
 
+      # The compiler is written in Salam, so building it needs one. Used to
+      # come from `make -C c`; that is gone, so a released binary seeds it.
+      - name: Install a seed compiler
+        uses: ./.github/actions/setup-salam
+
       - name: Set up pinned tcc
         uses: ./.github/actions/setup-tcc
 

--- a/.github/workflows/editor-playground-deploy.yml
+++ b/.github/workflows/editor-playground-deploy.yml
@@ -32,6 +32,11 @@ jobs:
         with:
           persist-credentials: false
 
+      # The compiler is written in Salam, so building it needs one. Used to
+      # come from `make -C c`; that is gone, so a released binary seeds it.
+      - name: Install a seed compiler
+        uses: ./.github/actions/setup-salam
+
       - name: Set up pinned tcc
         uses: ./.github/actions/setup-tcc
 

--- a/.github/workflows/extension-vscode.yml
+++ b/.github/workflows/extension-vscode.yml
@@ -80,8 +80,14 @@ jobs:
       - name: Install workspace dependencies
         run: bun install --frozen-lockfile
 
+      # SALAM_STD because these run from extensions/vscode: a self-hosted salam
+      # has no stdlib compiled into it and no salam.cfg beside it there, so it
+      # reported every std package missing ("standard library package 'node'
+      # not found") and that read as 135 errors in the extension source.
       - name: Compile the extension
         working-directory: extensions/vscode
+        env:
+          SALAM_STD: ${{ github.workspace }}/std
         run: |
           set -eu
           salam js src/extension.salam --output=out/extension.js
@@ -91,6 +97,8 @@ jobs:
       - name: Package
         id: pack
         working-directory: extensions/vscode
+        env:
+          SALAM_STD: ${{ github.workspace }}/std
         run: |
           set -eu
           version=$(node -p "require('./package.json').version")

--- a/.github/workflows/extension-vscode.yml
+++ b/.github/workflows/extension-vscode.yml
@@ -50,8 +50,16 @@ jobs:
 
       # The compiler is written in Salam, so building it needs one. Used to
       # come from `make -C c`; that is gone, so a released binary seeds it.
+      # add-to-path: false on purpose. The extension is written against the
+      # compiler in this tree, and a released seed lags it - with both on PATH
+      # the seed won and `salam js src/extension.salam` came back with 135
+      # semantic errors. The seed is passed to the build by path instead, so
+      # the only salam on PATH is the one built below.
       - name: Install a seed compiler
+        id: seed
         uses: ./.github/actions/setup-salam
+        with:
+          add-to-path: 'false'
 
       # Built from this checkout rather than installed from the last release:
       # the extension is written against the compiler in this tree, and a
@@ -60,7 +68,7 @@ jobs:
       - name: Build the salam compiler from source
         run: |
           set -eu
-          sh tools/bash/build-selfhost.sh
+          sh tools/bash/build-selfhost.sh --seed="${{ steps.seed.outputs.salam }}"
           ./salam version
           pwd >> "$GITHUB_PATH"
 

--- a/.github/workflows/extension-vscode.yml
+++ b/.github/workflows/extension-vscode.yml
@@ -90,6 +90,10 @@ jobs:
           SALAM_STD: ${{ github.workspace }}/std
         run: |
           set -eu
+          # salam js will not create a missing parent directory, and out/ is
+          # gitignored, so a fresh checkout has none. package.json's scripts do
+          # this themselves; this step calls the compiler directly and has to.
+          mkdir -p out
           salam js src/extension.salam --output=out/extension.js
           [ -s out/extension.js ] || { echo "::error::out/extension.js is empty or missing"; exit 1; }
           ls -l out/extension.js

--- a/.github/workflows/extension-vscode.yml
+++ b/.github/workflows/extension-vscode.yml
@@ -48,6 +48,11 @@ jobs:
         with:
           persist-credentials: false
 
+      # The compiler is written in Salam, so building it needs one. Used to
+      # come from `make -C c`; that is gone, so a released binary seeds it.
+      - name: Install a seed compiler
+        uses: ./.github/actions/setup-salam
+
       # Built from this checkout rather than installed from the last release:
       # the extension is written against the compiler in this tree, and a
       # published build lags it. This is the cheap C build (a few seconds),

--- a/.github/workflows/llvm-selfhost-gate.yml
+++ b/.github/workflows/llvm-selfhost-gate.yml
@@ -49,23 +49,25 @@ jobs:
         with:
           persist-credentials: false
 
+      # LLVM 22 from apt.llvm.org, the same version the release builds
+      # against - not the distro default, which this used to track. std/llvm
+      # calls ORC C entry points that only exist from LLVM 20 on
+      # (LLVMOrcCreateNewThreadSafeContextFromLLVMContext among them), so on
+      # Ubuntu's 18.1 the link fails on symbols the API simply did not have
+      # yet. Gating against a version we do not ship tests nothing useful.
       - name: Install LLVM and lld
         run: |
+          set -eu
+          wget -qO llvm.sh https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 22
           sudo apt-get update
-          sudo apt-get install -y llvm-dev liblld-dev libzstd-dev zlib1g-dev
-          # libpolly-N-dev is not optional, and this workflow was the only one
-          # omitting it (compiler-release, compiler-selfhost and
-          # lint-memory-leaks all install it explicitly). Ubuntu's llvm-N-dev
-          # advertises Polly through `llvm-config --libs all` AND builds
-          # libLLVMLTO.a against it, while shipping libPolly.a in a separate
-          # package - so without it the link fails whichever way the Makefile
-          # jumps: keeping -lPolly gives "cannot find -lPolly", dropping it
-          # gives "undefined reference to getPollyPluginInfo()".
-          #
-          # The version is derived rather than pinned because this job
-          # deliberately tracks the distro's default llvm-dev.
-          v="$(llvm-config --version | cut -d. -f1)"
-          sudo apt-get install -y "libpolly-$v-dev"
+          # libpolly is not optional: llvm-N-dev advertises Polly through
+          # `llvm-config --libs all` and builds libLLVMLTO.a against it, while
+          # shipping libPolly.a separately - without it the link fails either
+          # way, on -lPolly or on getPollyPluginInfo().
+          sudo apt-get install -y llvm-22-dev liblld-22-dev libpolly-22-dev \
+            libzstd-dev zlib1g-dev libtinfo-dev libxml2-dev
 
       - name: Install a seed compiler
         uses: ./.github/actions/setup-salam
@@ -73,7 +75,9 @@ jobs:
       # The archive std/llvm links against, built from the native shim plus
       # every static LLVM/LLD archive on the runner.
       - name: Build libsalam_llvm.a
-        run: sh std/llvm/native/build.sh --out "$GITHUB_WORKSPACE"
+        run: |
+          sh std/llvm/native/build.sh --llvm-config llvm-config-22 \
+            --out "$GITHUB_WORKSPACE"
 
       - name: Build the compiler with LLVM in-process
         run: sh tools/bash/build-selfhost.sh --llvm="$GITHUB_WORKSPACE"

--- a/benchmark/docker/Dockerfile
+++ b/benchmark/docker/Dockerfile
@@ -76,9 +76,16 @@ RUN addgroup -g "${SALAM_GID}" salam \
 ENV GOCACHE=/tmp/go-cache GOPATH=/tmp/go CARGO_HOME=/tmp/cargo
 WORKDIR /repo
 
-FROM toolchain AS salam-builder
-# The compiler is written in Salam, so building it needs one. The seed is a
-# released binary, fetched here rather than built - `make -C c` is gone.
+# A glibc base, not the Alpine toolchain stage: the published seed is
+# glibc-linked and will not run under musl at all - gcompat does not carry
+# libxml2 or the __isoc23_* symbols it needs. So the compiler is built here and
+# emitted for x86_64-linux-musl, which is static and runs in the bench stage.
+# The seed carries its own musl sysroot, so no cross toolchain is installed.
+FROM debian:stable-slim AS salam-builder
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates curl unzip gcc libc6-dev git libxml2 \
+    && rm -rf /var/lib/apt/lists/*
 ARG SALAM_SEED_SLUG=linux
 COPY tools /repo/tools
 COPY compiler /repo/compiler
@@ -86,7 +93,10 @@ COPY std /repo/std
 COPY VERSION /repo/VERSION
 WORKDIR /repo
 RUN sh tools/bash/fetch-seed.sh --slug "${SALAM_SEED_SLUG}" --out /repo/seed \
-    && sh tools/bash/build-selfhost.sh --seed=/repo/seed/salam --output=/repo/salam
+    && sh tools/bash/build-selfhost.sh --seed=/repo/seed/salam \
+    --output=/repo/salam -- --target=x86_64-linux-musl
+# Proof it is the static musl binary the bench stage needs, not a glibc one
+# that would die there the same way the seed does.
 RUN /repo/salam version
 
 FROM toolchain AS bench

--- a/benchmark/docker/Dockerfile
+++ b/benchmark/docker/Dockerfile
@@ -30,6 +30,8 @@ RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \
             py3-numpy \
             bash \
             git \
+            curl \
+            unzip \
             coreutils \
             sqlite-dev \
             sqlite-static \
@@ -75,10 +77,16 @@ ENV GOCACHE=/tmp/go-cache GOPATH=/tmp/go CARGO_HOME=/tmp/cargo
 WORKDIR /repo
 
 FROM toolchain AS salam-builder
-COPY c /repo/c
-WORKDIR /repo/c
-RUN make -j"$(nproc)"
+# The compiler is written in Salam, so building it needs one. The seed is a
+# released binary, fetched here rather than built - `make -C c` is gone.
+ARG SALAM_SEED_SLUG=linux
+COPY tools /repo/tools
+COPY compiler /repo/compiler
+COPY std /repo/std
+COPY VERSION /repo/VERSION
 WORKDIR /repo
+RUN sh tools/bash/fetch-seed.sh --slug "${SALAM_SEED_SLUG}" --out /repo/seed \
+    && sh tools/bash/build-selfhost.sh --seed=/repo/seed/salam --output=/repo/salam
 RUN /repo/salam version
 
 FROM toolchain AS bench

--- a/compiler/cli/cli_debug.salam
+++ b/compiler/cli/cli_debug.salam
@@ -91,6 +91,11 @@ func memcheck_cmd(opt &: dr.Dr): int:
     mut use_valgrind := false
     if !SALAM_OS_WINDOWS:
         use_valgrind = os.Run("valgrind --version > /dev/null 2>&1") == 0
+    else:
+        // Spelled out rather than left to the initializer: with a Windows
+        // target condcomp prunes the arm above, and a `mut` that is never
+        // assigned is an error (E069). There is no Valgrind here either way.
+        use_valgrind = false
     end
 
     // tcc cannot instrument for ASan, but it emits a perfectly good binary for

--- a/compiler/driver/driver_api_tools.salam
+++ b/compiler/driver/driver_api_tools.salam
@@ -130,6 +130,11 @@ import co "../sal_core.salam"
         mut use_valgrind := false
         if !SALAM_OS_WINDOWS:
             use_valgrind = system("valgrind --version > /dev/null 2>&1") == 0
+        else:
+            // Spelled out rather than left to the initializer: with a Windows
+            // target condcomp prunes the arm above, and a `mut` that is never
+            // assigned is an error (E069). There is no Valgrind here either way.
+            use_valgrind = false
         end
 
         // tcc cannot instrument for ASan, but it emits a perfectly good binary

--- a/compiler/llvmgen/llvm_api.salam
+++ b/compiler/llvmgen/llvm_api.salam
@@ -517,6 +517,7 @@ pub func RunOpts(
         toplevel(v, s, a, at.Child(a, program, i))
         i += 1
     end
+    linker_options_finalize(v)
     debug_finalize(v)
     if co.SbLen(v.bhg) > (0 as i64):
         out_g(v, "; on-demand runtime helpers\n")

--- a/compiler/llvmgen/llvm_debug.salam
+++ b/compiler/llvmgen/llvm_debug.salam
@@ -130,6 +130,26 @@ func debug_location(v &: Lv, line: int, col: int): str:
     )
 end
 
+// linker_options_finalize - flushes the -alternatename aliases collected by
+// declare_extern into !llvm.linker.options, which the COFF backend writes
+// into the object's .drectve section for the linker to read.
+//
+// Runs before debug_finalize because that one flushes the metadata buffer
+// these nodes have to already be in.
+func linker_options_finalize(v &: Lv):
+    if v.extern_stdcall.len() == 0:
+        ret
+    end
+    mut ids := ""
+    repeat v.extern_stdcall.len() with i:
+        if i != 0:
+            ids += ", "
+        end
+        ids += meta_add(v, `!{!"` + v.extern_stdcall.get(i) + `"}`)
+    end
+    out_g(v, "\n!llvm.linker.options = !{" + ids + "}\n")
+end
+
 // ll_debug_finalize
 func debug_finalize(v &: Lv):
     // Also the flush point for TBAA nodes, which exist without -g.

--- a/compiler/llvmgen/llvm_globals.salam
+++ b/compiler/llvmgen/llvm_globals.salam
@@ -479,6 +479,52 @@ func body_sig_for(s &: sm.Sema, a &: at.Ast, name: str, owner &: int): int:
     ret 0 - 1
 end
 
+// stdcall_alias_for - the "-alternatename:_F=_F@N" a 32-bit Windows link
+// needs for one extern function, or "" when it needs none.
+//
+// Win32 APIs are stdcall on i386, so kernel32 & co. export them decorated
+// (`_GetFileType@4`, verified with nm on libkernel32.a) while the plain
+// `extern func GetFileType(...)` this compiler emits references the bare
+// `_GetFileType`. On x86_64 there is no decoration and the two coincide,
+// which is why only the 32-bit Windows build ever broke - it stopped with
+// every Win32 import undefined.
+//
+// The alias is emitted for EVERY extern, not just the ones that turn out to
+// be stdcall, because nothing in the source says which is which. That costs
+// nothing: `-alternatename` is consulted only for a symbol that is still
+// undefined once everything has been scanned, so a cdecl extern like fopen
+// resolves normally and its alias is never looked at. It is the same idea
+// as GNU ld's --enable-stdcall-fixup, except it names the exact symbol
+// instead of searching, and unlike that flag it works under lld, which does
+// no stdcall fixup of its own (checked against lld 21 in mingw mode).
+//
+// A variadic extern is cdecl by definition and gets no alias.
+func stdcall_alias_for(v &: Lv, s &: sm.Sema, a &: at.Ast, name: str, sg &: sm.Sig): str:
+    if !target_is_windows_of(v.triple) || target_ptr_bits_of(v.triple) != 32:
+        ret ""
+    end
+    if sg.variadic:
+        ret ""
+    end
+    mut bytes := 0
+    repeat sg.params.len() with j:
+        t := ty_of(v, s, a, sm.ToString(s, sg.params.get(j)))
+        if str.Equals(t, "i64") || str.Equals(t, "double"):
+            bytes += 8
+        else str.Equals(t, "ptr") || str.Equals(t, "i32") || str.Equals(t, "i16") || str.Equals(t, "i8") || str.Equals(t, "i1") || str.Equals(t, "float"):
+            // Everything narrower than a word is passed in a whole stack
+            // slot, so it counts as 4.
+            bytes += 4
+        else:
+            // An aggregate passed by value has no simple byte count; rather
+            // than guess a wrong @N, emit no alias at all.
+            ret ""
+        end
+    end
+    dec := "_" + name + "@" + co.I64Toa(bytes as i64)
+    ret "-alternatename:_" + name + "=" + dec
+end
+
 // ll_declare_extern - one bodyless `extern func` -> one `declare` line,
 // de-duplicated against everything already declared or defined.
 //
@@ -510,6 +556,10 @@ func declare_extern(v &: Lv, s &: sm.Sema, a &: at.Ast, name: str, sigid: int):
         ret
     end
     v.extern_names.push(name)
+    alias := stdcall_alias_for(v, s, a, name, sg)
+    if str.Len(alias) > 0:
+        v.extern_stdcall.push(alias)
+    end
     dn2 := at.Get(a, sg.decl)
     mut b := co.SbNew()
     co.SbPuts(

--- a/compiler/llvmgen/llvmgen.salam
+++ b/compiler/llvmgen/llvmgen.salam
@@ -330,6 +330,9 @@ pub struct Lv:
     pub globals: Vector<LvVar> = Vector {}
     pub gdefer: Vector<int> = Vector {} // indices into `globals`
     pub extern_names: Vector<str> = Vector {}
+    // One "-alternatename:_F=_F@N" per extern function, for 32-bit Windows
+    // targets only; empty everywhere else. See stdcall_alias_for.
+    pub extern_stdcall: Vector<str> = Vector {}
     pub pkg_scope: int = 0 // sm ScopeId (0 = C NULL)
     pub emitted: Vector<str> = Vector {}
     pub pkg_touched: Vector<int> = Vector {} // sm SymIds
@@ -475,6 +478,7 @@ func new_lv0(): Lv:
     v.globals = Vector {} as Vector<LvVar>
     v.gdefer = Vector {} as Vector<int>
     v.extern_names = Vector {} as Vector<str>
+    v.extern_stdcall = Vector {} as Vector<str>
     v.emitted = Vector {} as Vector<str>
     v.pkg_touched = Vector {} as Vector<int>
     v.hneed = Vector {} as Vector<bool>
@@ -500,6 +504,7 @@ func free_lv(v &: Lv):
     v.globals.free()
     v.gdefer.free()
     v.extern_names.free()
+    v.extern_stdcall.free()
     v.emitted.free()
     v.pkg_touched.free()
     v.hneed.free()

--- a/compiler/repl.salam
+++ b/compiler/repl.salam
@@ -258,7 +258,7 @@ if SALAM_OS_WINDOWS:
     // a 24-byte buffer, EventType:u16@0, KeyEvent.bKeyDown:i32@4,
     // KeyEvent.wVirtualKeyCode:u16@10, KeyEvent.uChar.AsciiChar:i8@14.
     func win_readline(prompt: str, ok &: bool): str:
-        hIn := GetStdHandle(STD_INPUT_HANDLE as i32)
+        hIn := GetStdHandle(STD_INPUT_HANDLE)
         invalid := (hIn as i64) == (0 - 1)
         mut is_char := false
         if !invalid:

--- a/compiler/wasm_main.salam
+++ b/compiler/wasm_main.salam
@@ -1,0 +1,32 @@
+/*
+ * Salam Programming Language (2024-2026)
+ *
+ *   +-------------------+
+ *   |     S A L A M     |
+ *   +-------------------+
+ *
+ * Designed by Seyyed Ali Mohammadiyeh and the Salam Team
+ * Born from a decade of language design experience (since 2018)
+ *
+ * Repository: https://github.com/SalamLang/Salam
+ *
+ */
+
+// Entry point for the WebAssembly playground build, and only for it.
+//
+// main.salam is the CLI compiler and never reaches sal_web.salam, the same way
+// the C build compiled c/src/web only inside build-wasm.sh. Importing it here
+// is what pulls in its `extern:` shims - salam_web_run_app and the rest - which
+// survive DCE and keep their unmangled names, so emscripten can export them.
+//
+// The entry itself does nothing: the browser calls the exported functions
+// directly through cwrap, and emcc is told IGNORE_MISSING_MAIN, but a program
+// still needs one to compile.
+package main
+
+import web "sal_web.salam"
+
+func main:
+    // Referenced so the import is not an unused one; the value is discarded.
+    _v := web.Version()
+end

--- a/std/core/core.salam
+++ b/std/core/core.salam
@@ -105,21 +105,25 @@ extern:
         _salam_argc = argc
         _salam_argv = argv
     end
+    // Indexed as `str*`, not `i64*`: argv is an array of pointers, and on a
+    // 32-bit host those are 4 bytes each. Reading it through an i64* view
+    // fetched two argv entries glued together as one address, and the
+    // strlen() on that garbage pointer segfaulted before main ever ran -
+    // which is what a 32-bit self-hosted build died of on startup. sizeof
+    // keeps the allocation in step with the element type.
     func salam_args(out_count: void*): void*:
         oc := out_count as int*
         n := _salam_argc
         mut slots := n
         if slots < 1: slots = 1 end
-        arr := mem.Allocate((slots * 8) as u64)
-        a64 := arr as i64*
-        av := _salam_argv as i64*
+        arr := mem.Allocate((slots as u64) * (sizeof(str) as u64)) as str*
+        av := _salam_argv as str*
         repeat n with i:
-            cp := av[i] as void*
-            s := cp as str
-            a64[i] = _strptr(s.substr(0, s.len()))
+            s := av[i]
+            arr[i] = s.substr(0, s.len())
         end
         oc[0] = n
-        ret arr
+        ret arr as void*
     end
 end
 

--- a/std/fs/fs.salam
+++ b/std/fs/fs.salam
@@ -141,10 +141,10 @@ func _ld_push(arr: void*, n: int, cap_box: void*, name: str): void*:
         if cap[0] == 0: cap[0] = 8 else:
             cap[0] = cap[0] * 2
         end
-        a = mem.Reallocate(a, (cap[0] * 8) as u64)
+        a = mem.Reallocate(a, (cap[0] as u64) * (sizeof(str) as u64))
     end
-    a64 := a as i64*
-    a64[n] = _strptr(name.substr(0, name.len()))
+    slots := a as str*
+    slots[n] = name.substr(0, name.len())
     ret a
 end
 
@@ -191,7 +191,15 @@ else:
     else SALAM_OS_BSD:
         func _dname_off(): i64: ret 24 end
     else:
-        func _dname_off(): i64: ret 19 end
+        // 19 only holds where dirent's d_ino and d_off are 8 bytes each.
+        // On 32-bit glibc, plain `readdir` is the non-LFS one: 4 + 4 + 2 + 1
+        // puts d_name at 11, measured with offsetof in an i386 container.
+        // Reading the name 8 bytes late there handed str.EndsWith an
+        // address past the entry, which segfaulted.
+        func _dname_off(): i64:
+            if sizeof(void*) == 4: ret 11 end
+            ret 19
+        end
     end
     extern:
         func salam_os_listdir(path: str, out_count: void*): void*:

--- a/std/llvm/linker.salam
+++ b/std/llvm/linker.salam
@@ -35,11 +35,11 @@ end
 
 // ArgvOf - marshals a Vector<str> into a contiguous char*[] (as a `str*`,
 // ABI-identical to lld_link.h's `const char *const *argv`) for
-// salam_lld_link. Pointer width is assumed to be 8 bytes, same assumption
-// std/mem/mem.salam's own HDR_SIZE already makes for this host - not
-// portable to a 32-bit self-host build, same known limitation.
+// salam_lld_link. The size comes from sizeof(str) rather than a hardcoded
+// 8: this used to assume a 64-bit pointer and under-allocate by half on a
+// 32-bit host, writing past the end of the buffer for every argument.
 func argv_of(items: Vector<str>): void*:
-    mut buf := mem.Allocate((items.len() * 8) as u64) as str*
+    mut buf := mem.Allocate((items.len() as u64) * (sizeof(str) as u64)) as str*
     repeat items.len() with i:
         buf[i] = items.get(i)
     end

--- a/std/llvm/llvm.salam
+++ b/std/llvm/llvm.salam
@@ -122,6 +122,13 @@ else:
     // Linux and carries its own DT_NEEDED, which is also how upstream LLVM's
     // own tools link it.
     link dynamic "xml2"
+    // LLVM asks the terminal whether it supports colour through terminfo
+    // (Process::FileDescriptorHasColors -> tigetnum/set_curterm/del_curterm),
+    // which lives in libtinfo. Without it the link fails on those three
+    // symbols alone. Dynamic for the same reason as xml2: libtinfo.so is on
+    // every mainstream Linux, and a static one drags in more than it is
+    // worth.
+    link dynamic "tinfo"
     link static "stdc++"
 end
 

--- a/std/llvm/llvm.salam
+++ b/std/llvm/llvm.salam
@@ -63,10 +63,14 @@ if SALAM_OS_WINDOWS:
     link dynamic "advapi32"
     link dynamic "ws2_32"
     link dynamic "ntdll"
-    link static "z"
-    link static "zstd"
+    // xml2 before z, for the same reason the C++ runtime comes after
+    // libsalam_llvm.a: libxml2.a calls gzread/gzclose/gzdopen, so libz.a has
+    // to still be ahead of the linker when those references show up. With z
+    // first the link ended in "undefined reference to `gzread'".
     link static "xml2"
     link static "iconv"
+    link static "z"
+    link static "zstd"
     link dynamic "bcrypt"
     link static "stdc++"
     link static "gcc_eh"

--- a/std/llvm/native/build.sh
+++ b/std/llvm/native/build.sh
@@ -108,6 +108,19 @@ lld_includedir() {
 }
 
 WORK=$(mktemp -d)
+
+# llvm-ar on MSYS2 is a native Windows binary reading an MRI script full of
+# paths this shell writes. It cannot resolve an MSYS path like /tmp/tmp.XXXX,
+# so every "addmod" line came back as "No such file or directory". Everything
+# that goes INTO the script gets converted; everything used by the shell itself
+# stays as it is.
+to_ar_path() {
+    if command -v cygpath >/dev/null 2>&1; then
+        cygpath -m "$1"
+    else
+        printf '%s' "$1"
+    fi
+}
 trap 'rm -rf "$WORK"' EXIT INT TERM
 
 echo "llvm-config : $LLVM_CONFIG ($($LLVM_CONFIG --version))"
@@ -154,8 +167,8 @@ esac
 MRI=$WORK/mri
 mkdir -p "$OUT"
 : >"$MRI"
-echo "create $OUT/libsalam_llvm.a" >>"$MRI"
-for o in $SHIMS; do echo "addmod $o" >>"$MRI"; done
+echo "create $(to_ar_path "$OUT/libsalam_llvm.a")" >>"$MRI"
+for o in $SHIMS; do echo "addmod $(to_ar_path "$o")" >>"$MRI"; done
 
 # A host can have llvm-config and the headers and still have no static
 # components at all (a shared-only LLVM package). Left unchecked, every
@@ -182,7 +195,7 @@ missing_llvm=
 for l in $LLVM_LIBS $(for x in $LLD_LIBS; do echo "-l$x"; done); do
     case "$l" in -l*) nm="lib${l#-l}.a" ;; *) continue ;; esac
     if a=$(find_lib "$nm"); then
-        echo "addlib $a" >>"$MRI"
+        echo "addlib $(to_ar_path "$a")" >>"$MRI"
         n=$((n + 1))
     else
         case "$nm" in

--- a/std/os/process/process.salam
+++ b/std/os/process/process.salam
@@ -139,16 +139,19 @@ if SALAM_OS_WINDOWS:
         ret h
     end
 else:
+    // char*[] for execv, so the slots are pointer-sized: sizeof(str), not a
+    // hardcoded 8. With 8 this under-allocated by half on a 32-bit host and
+    // wrote every argument two slots apart, leaving execv a garbage vector.
     func _build_argv(path: str, args: Vector<str>): void*:
         n := args.len()
-        arr := mem.Allocate(((n + 2) as u64) * (8 as u64)) as i64*
-        arr[0] = _strptr(path)
+        arr := mem.Allocate(((n + 2) as u64) * (sizeof(str) as u64)) as str*
+        arr[0] = path
         mut i := 0
         until i < n:
-            arr[i + 1] = _strptr(args.get(i))
+            arr[i + 1] = args.get(i)
             i += 1
         end
-        arr[n + 1] = 0 as i64
+        arr[n + 1] = null as str
         ret arr as void*
     end
 

--- a/std/text/text.salam
+++ b/std/text/text.salam
@@ -142,11 +142,14 @@ extern:
         dl := delim.len()
         n := s.len()
         if dl == 0:
-            arr := mem.Allocate(8 as u64)
-            a64 := arr as i64*
-            a64[0] = _copy_range(s, 0, n)
+            // sizeof(str), not 8: the caller reads this back as a char*[],
+            // whose elements are 4 bytes wide on a 32-bit host. Allocating
+            // and indexing it as i64 under-allocated by half and returned
+            // pairs of pointers glued together as single addresses.
+            arr := mem.Allocate(sizeof(str) as u64) as str*
+            arr[0] = (_copy_range(s, 0, n) as void*) as str
             oc[0] = 1
-            ret arr
+            ret arr as void*
         end
         mut count := 1
         mut idx := _find_from(s, delim, 0)
@@ -154,19 +157,18 @@ extern:
             count += 1
             idx = _find_from(s, delim, idx + dl)
         end
-        arr := mem.Allocate((count * 8) as u64)
-        a64 := arr as i64*
+        arr := mem.Allocate((count as u64) * (sizeof(str) as u64)) as str*
         mut k := 0
         mut off := 0
         idx = _find_from(s, delim, 0)
         until idx >= 0:
-            a64[k] = _copy_range(s, off, idx - off)
+            arr[k] = (_copy_range(s, off, idx - off) as void*) as str
             k += 1
             off = idx + dl
             idx = _find_from(s, delim, off)
         end
-        a64[k] = _copy_range(s, off, n - off)
+        arr[k] = (_copy_range(s, off, n - off) as void*) as str
         oc[0] = count
-        ret arr
+        ret arr as void*
     end
 end

--- a/tests/en/apps/httpbench/bench/run.sh
+++ b/tests/en/apps/httpbench/bench/run.sh
@@ -92,7 +92,7 @@ build_salam() {
     fi
     [ -n "${SALAM_BIN:-}" ] && [ -x "$SALAM_BIN" ] ||
         {
-            echo "no salam binary (run: make -C c)" >&2
+            echo "no salam binary (run: sh tools/bash/build-selfhost.sh)" >&2
             exit 1
         }
     say "building httpbench with $SALAM_BIN"

--- a/tools/bash/build-embed.sh
+++ b/tools/bash/build-embed.sh
@@ -109,7 +109,10 @@ done
 # armhf jobs failed with "cannot represent relocation type BFD_RELOC_64". The
 # length stays .quad either way: Salam reads it as an i64, and a difference
 # between two symbols in one section is resolved at assembly time rather than
-# through a relocation.
+# through a relocation. That i64 then needs .balign 8 of its own, because a
+# 4-byte .long pointer ahead of it would otherwise leave it 4-byte aligned -
+# harmless on x86, a fault on armhf, where a 64-bit load wants its natural
+# alignment.
 case "$($CC -dumpmachine 2>/dev/null)" in
 i?86-* | arm-* | armv7*-* | armhf-* | powerpc-* | mips-* | mipsel-*) PTR=.long ;;
 *) PTR=.quad ;;
@@ -147,8 +150,10 @@ emit() {
             printf '.incbin "%s"\n' "$(to_native_path "$WORK/$stem.tar")"
             printf '%s_end:\n' "$stem"
             printf '.section .data\n'
+            printf '.balign 8\n'
             printf '.globl salam_embed_%s_ptr\n' "$stem"
             printf 'salam_embed_%s_ptr: %s %s_data\n' "$stem" "$PTR" "$stem"
+            printf '.balign 8\n'
             printf '.globl salam_embed_%s_len\n' "$stem"
             printf 'salam_embed_%s_len: .quad %s_end - %s_data\n' "$stem" "$stem" "$stem"
         } >>"$S"
@@ -159,8 +164,10 @@ emit() {
         # needs no per-target conditional.
         {
             printf '.section .data\n'
+            printf '.balign 8\n'
             printf '.globl salam_embed_%s_ptr\n' "$stem"
             printf 'salam_embed_%s_ptr: %s 0\n' "$stem" "$PTR"
+            printf '.balign 8\n'
             printf '.globl salam_embed_%s_len\n' "$stem"
             printf 'salam_embed_%s_len: .quad 0\n' "$stem"
         } >>"$S"

--- a/tools/bash/build-embed.sh
+++ b/tools/bash/build-embed.sh
@@ -104,6 +104,29 @@ while [ $# -gt 0 ]; do
     esac
 done
 
+# A pointer is 4 bytes on a 32-bit target and 8 on a 64-bit one, and `.quad`
+# against a symbol simply cannot be relocated in a 32-bit object - the i386 and
+# armhf jobs failed with "cannot represent relocation type BFD_RELOC_64". The
+# length stays .quad either way: Salam reads it as an i64, and a difference
+# between two symbols in one section is resolved at assembly time rather than
+# through a relocation.
+case "$($CC -dumpmachine 2>/dev/null)" in
+i?86-* | arm-* | armv7*-* | armhf-* | powerpc-* | mips-* | mipsel-*) PTR=.long ;;
+*) PTR=.quad ;;
+esac
+
+# The assembler on MSYS2 is a native Windows binary and cannot resolve an MSYS
+# path like /tmp/tmp.XXXX, so every .incbin came back as "file not found" while
+# the .S itself opened fine. Only paths that go INTO the generated assembly get
+# converted; the ones this shell uses stay as they are.
+to_native_path() {
+    if command -v cygpath >/dev/null 2>&1; then
+        cygpath -m "$1"
+    else
+        printf '%s' "$1"
+    fi
+}
+
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT INT TERM
 mkdir -p "$OUT"
@@ -121,11 +144,11 @@ emit() {
         {
             printf '.section .rodata\n'
             printf '%s_data:\n' "$stem"
-            printf '.incbin "%s/%s.tar"\n' "$WORK" "$stem"
+            printf '.incbin "%s"\n' "$(to_native_path "$WORK/$stem.tar")"
             printf '%s_end:\n' "$stem"
             printf '.section .data\n'
             printf '.globl salam_embed_%s_ptr\n' "$stem"
-            printf 'salam_embed_%s_ptr: .quad %s_data\n' "$stem" "$stem"
+            printf 'salam_embed_%s_ptr: %s %s_data\n' "$stem" "$PTR" "$stem"
             printf '.globl salam_embed_%s_len\n' "$stem"
             printf 'salam_embed_%s_len: .quad %s_end - %s_data\n' "$stem" "$stem" "$stem"
         } >>"$S"
@@ -137,7 +160,7 @@ emit() {
         {
             printf '.section .data\n'
             printf '.globl salam_embed_%s_ptr\n' "$stem"
-            printf 'salam_embed_%s_ptr: .quad 0\n' "$stem"
+            printf 'salam_embed_%s_ptr: %s 0\n' "$stem" "$PTR"
             printf '.globl salam_embed_%s_len\n' "$stem"
             printf 'salam_embed_%s_len: .quad 0\n' "$stem"
         } >>"$S"

--- a/tools/bash/build-selfhost.sh
+++ b/tools/bash/build-selfhost.sh
@@ -141,7 +141,12 @@ echo "output : $OUT"
 # the same reason bootstrap.sh lets the seed decide only what stage 1 gets.
 if [ -n "$EMBED_DIR" ]; then
     echo "stage 1: a plain compiler, to build the embedded one with"
-    "$SEED" build "$ROOT/compiler/main.salam" --output="$OUT.stage1"
+    # --backend=c on purpose. Stage 1 is throwaway - it only has to be a
+    # working compiler for one build - so it takes the conservative path
+    # rather than depending on the seed's LLVM codegen. On i686 that
+    # dependency was not hypothetical: the seed's LLVM backend produced a
+    # stage 1 that linked fine and segfaulted the moment it ran.
+    "$SEED" build --backend=c "$ROOT/compiler/main.salam" --output="$OUT.stage1"
     BUILDER=$OUT.stage1
 else
     BUILDER=$SEED

--- a/tools/bash/build-wasm.sh
+++ b/tools/bash/build-wasm.sh
@@ -57,7 +57,7 @@ mkdir -p "$OUT_DIR"
 # and blank lines while leaving the token stream identical (verified across
 # all stdlib files), worth another ~500 KB the browser would download and
 # then discard, since the lexer drops that trivia anyway.
-STD_MIN="$(pwd)/c/build/std-min"
+STD_MIN="$(pwd)/.wasm-build/std-min"
 rm -rf "$STD_MIN"
 mkdir -p "$STD_MIN"
 (
@@ -69,17 +69,30 @@ mkdir -p "$STD_MIN"
 )
 "$SALAM" format --minify -r "$STD_MIN" >/dev/null
 echo "staged minified stdlib preload image at $STD_MIN"
-SRC_DIRS="core source logger xml condcomp token langpack i18n lexer ast parser
-        diag semantic interp layout minify codegen llvm jsgen web"
-SRCS=""
-for d in $SRC_DIRS; do SRCS="$SRCS c/src/$d/*.c"; done
-# js_build.c only, not all of src/driver: it is the bundler that turns jsgen's
-# per-module output into one runnable program (prelude, globals, entry call),
-# which is exactly what salam_web_compile_js needs. The rest of the driver
-# shells out to a C toolchain and has no meaning in the browser.
-SRCS="$SRCS c/src/driver/js_build.c"
+
+# The compiler is Salam now, so the C emcc compiles is what the C backend
+# emits rather than a hand-written src tree. --keep-c leaves those units in
+# .salam-build; the link it also attempts is for this host and irrelevant
+# here, so its failure is not an error.
+#
+# compiler/sal_web.salam already exports salam_web_run_app and friends under
+# those exact names: a `func` with a body inside an `extern:` block survives
+# DCE and keeps its unmangled symbol, which is Salam's EMSCRIPTEN_KEEPALIVE.
+rm -rf .salam-build
+"$SALAM" build --backend=c --keep-c compiler/main.salam \
+    --output=.wasm-build/host-salam --log-level=warn >/dev/null 2>&1 || true
+SRCS=$(find .salam-build -name '*.c' | sort | tr '\n' ' ')
+[ -n "$SRCS" ] || {
+    echo "no generated C in .salam-build; the compiler build produced nothing" >&2
+    exit 1
+}
+
+# salam_web_compile_js is not in this list: it was a C-only entry point and
+# the self-hosted sal_web.salam has no counterpart. editor/app.salam cwraps
+# run_app, build_layout, emit and syntax_ok and never asked for it; JS output
+# comes through Emit()'s phase argument.
 # shellcheck disable=SC2086
-"$EMCC" -O2 -Ic/src $SRCS \
+"$EMCC" -O2 -I.salam-build $SRCS \
     -o "$OUT_DIR/salam-wa.js" \
     --preload-file "$STD_MIN"@/std \
     -s MODULARIZE=0 \
@@ -90,7 +103,7 @@ SRCS="$SRCS c/src/driver/js_build.c"
     -s EXIT_RUNTIME=0 \
     -s IGNORE_MISSING_MAIN=1 \
     -s FILESYSTEM=1 \
-    -s EXPORTED_FUNCTIONS="['_salam_web_run_app','_salam_web_compile_js','_salam_web_build_layout','_salam_web_emit','_salam_web_syntax_ok','_salam_web_version','_malloc','_free']" \
+    -s EXPORTED_FUNCTIONS="['_salam_web_run_app','_salam_web_build_layout','_salam_web_emit','_salam_web_syntax_ok','_salam_web_version','_malloc','_free']" \
     -s EXPORTED_RUNTIME_METHODS="['ccall','cwrap','UTF8ToString','stringToUTF8','lengthBytesUTF8','FS']"
 echo "built $OUT_DIR/salam-wa.js (+ .wasm, .data)"
 "$SALAM" web "$OUT_DIR/page.salam" --output="$OUT_DIR/index.html"

--- a/tools/bash/build-wasm.sh
+++ b/tools/bash/build-wasm.sh
@@ -79,7 +79,7 @@ echo "staged minified stdlib preload image at $STD_MIN"
 # those exact names: a `func` with a body inside an `extern:` block survives
 # DCE and keeps its unmangled symbol, which is Salam's EMSCRIPTEN_KEEPALIVE.
 rm -rf .salam-build
-"$SALAM" build --backend=c --keep-c compiler/main.salam \
+"$SALAM" build --backend=c --keep-c compiler/wasm_main.salam \
     --output=.wasm-build/host-salam --log-level=warn >/dev/null 2>&1 || true
 SRCS=$(find .salam-build -name '*.c' | sort | tr '\n' ' ')
 [ -n "$SRCS" ] || {

--- a/tools/bash/fetch-seed.sh
+++ b/tools/bash/fetch-seed.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+# Downloads a released salam for a platform other than this machine's, for
+# builds that happen inside a foreign-architecture container. setup-salam
+# installs the *runner's* architecture, which is the wrong one when the compile
+# runs under docker --platform=linux/386 or arm32v7.
+#
+# Usage:
+#   tools/bash/fetch-seed.sh --slug linux-i686 --out DIR [--version X.Y.Z]
+#
+# Without --version the newest published release is used.
+
+set -eu
+
+SLUG=
+OUT=$(pwd)/seed
+VERSION=
+REPO=${SALAM_REPO:-SalamLang/Salam}
+
+while [ $# -gt 0 ]; do
+    case $1 in
+    --slug)
+        SLUG=$2
+        shift 2
+        ;;
+    --slug=*)
+        SLUG=${1#*=}
+        shift
+        ;;
+    --out)
+        OUT=$2
+        shift 2
+        ;;
+    --out=*)
+        OUT=${1#*=}
+        shift
+        ;;
+    --version)
+        VERSION=$2
+        shift 2
+        ;;
+    --version=*)
+        VERSION=${1#*=}
+        shift
+        ;;
+    -h | --help)
+        sed -n '2,12p' "$0"
+        exit 0
+        ;;
+    *)
+        echo "unknown argument: $1" >&2
+        exit 2
+        ;;
+    esac
+done
+
+[ -n "$SLUG" ] || {
+    echo "error: --slug is required (linux-i686, linux-armhf, ...)" >&2
+    exit 2
+}
+
+if [ -z "$VERSION" ]; then
+    # Same shape setup-salam uses: read the tag out of the releases API and
+    # strip the leading v. Two seds rather than a pipeline into head, so a
+    # closed pipe cannot take the whole script down with SIGPIPE.
+    body=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest")
+    tag=$(printf '%s' "$body" | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | sed -n '1p')
+    [ -n "$tag" ] || {
+        echo "error: could not read the latest release tag" >&2
+        exit 1
+    }
+    VERSION=${tag#v}
+else
+    tag=v$VERSION
+fi
+
+asset="salam-${VERSION}-${SLUG}.zip"
+url="https://github.com/$REPO/releases/download/$tag/$asset"
+
+echo "seed asset : $asset ($tag)"
+rm -rf "$OUT"
+mkdir -p "$OUT"
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT INT TERM
+curl -fsSL --retry 3 -o "$tmp/seed.zip" "$url"
+unzip -q "$tmp/seed.zip" -d "$tmp/x"
+
+bin=$(find "$tmp/x" -name salam -type f 2>/dev/null | sed -n '1p')
+[ -n "$bin" ] || bin=$(find "$tmp/x" -name 'salam.exe' -type f 2>/dev/null | sed -n '1p')
+[ -n "$bin" ] || {
+    echo "error: no salam binary inside $asset" >&2
+    exit 1
+}
+# The whole tree, not just the binary: a release carries its own std/ beside it
+# and some builds resolve through that.
+cp -r "$(dirname "$bin")"/. "$OUT/"
+chmod +x "$OUT/$(basename "$bin")" 2>/dev/null || true
+echo "seed       : $OUT/$(basename "$bin")"

--- a/tools/bash/update-playground.sh
+++ b/tools/bash/update-playground.sh
@@ -75,7 +75,7 @@ for f in editor/salam-wa.js editor/salam-wa.wasm editor/salam-wa.data; do
     fi
 done
 echo "==> Exported entry points:"
-for sym in _salam_web_run_app _salam_web_compile_js _salam_web_build_layout _salam_web_emit _salam_web_syntax_ok; do
+for sym in _salam_web_run_app _salam_web_build_layout _salam_web_emit _salam_web_syntax_ok; do
     if grep -q "$sym" editor/salam-wa.js 2>/dev/null; then
         echo "    ok   $sym"
     else echo "    WARN missing $sym" >&2; fi

--- a/tools/mcp/mcp_docs.salam
+++ b/tools/mcp/mcp_docs.salam
@@ -117,20 +117,35 @@ func _hits_in(file_path: str, query: str, cap: int): Vector<str>:
 end
 
 // Pulls one {TK_..., "word"} table out of the compiler's langpack source.
+// The keyword spellings for one language, read out of the self-hosted
+// langpack's parallel arrays (k_kw_spell_en / _fa / _ar). Used to parse the C
+// compiler's kw_entry_t rows, which no longer exist; the data is the same, the
+// shape is a plain Salam array literal now.
 func _kw_table(src: str, array_name: str): Vector<str>:
     out := Vector {} as Vector<str>
     start := src.find(array_name)
     if start < 0: ret out end
     rest := src.substr(start, src.len() - start)
-    stop := rest.find("};")
-    mut body := rest
-    if stop > 0: body = rest.substr(0, stop) end
-    lines := mcptxt.Lines(body)
+    open_b := rest.find("[")
+    if open_b < 0: ret out end
+    stop := rest.find("]")
+    if stop < 0: ret out end
+    body := rest.substr(open_b + 1, stop - open_b - 1)
     mut i := 0
-    until i < lines.len():
-        ln := lines.get(i).trim()
-        if str.StartsWith(ln, "{TK_"):
-            out.push(_kw_pair(ln))
+    mut cur := ""
+    mut inside := false
+    until i < body.len():
+        c := body.substr(i, 1)
+        if str.Equals(c, "\""):
+            if inside:
+                if cur.len() > 0: out.push(cur) end
+                cur = ""
+                inside = false
+            else:
+                inside = true
+            end
+        else inside:
+            cur = cur.concat(c)
         end
         i += 1
     end
@@ -148,7 +163,7 @@ func _kw_pair(ln: str): str:
 end
 
 func _langpack_src(): str:
-    p := path.Join(mcpexec.Root(), "c/src/langpack/langpack_data.c")
+    p := path.Join(mcpexec.Root(), "compiler/langpack.salam")
     ret file.ReadText(p)
 end
 
@@ -159,9 +174,11 @@ func _word(pair: str): str:
 end
 
 func _row(en: Vector<str>, fa: Vector<str>, ar: Vector<str>, i: int): str:
+    // The spellings arrive bare now, not as "TK_x<tab>spelling" rows, so the
+    // token column is the English spelling and no splitting is needed.
     mut line := en.get(i)
-    if i < fa.len(): line = line.concat("\t").concat(_word(fa.get(i))) end
-    if i < ar.len(): line = line.concat("\t").concat(_word(ar.get(i))) end
+    if i < fa.len(): line = line.concat("\t").concat(fa.get(i)) end
+    if i < ar.len(): line = line.concat("\t").concat(ar.get(i)) end
     ret line
 end
 
@@ -274,9 +291,9 @@ pub func Keywords(): mcpout.ToolResult:
     if src.len() == 0:
         ret mcpout.Failure("langpack source not readable; set SALAM_MCP_ROOT to the Salam checkout.")
     end
-    en := _kw_table(src, "k_lang_en[]")
-    fa := _kw_table(src, "k_lang_fa[]")
-    ar := _kw_table(src, "k_lang_ar[]")
+    en := _kw_table(src, "k_kw_spell_en :=")
+    fa := _kw_table(src, "k_kw_spell_fa :=")
+    ar := _kw_table(src, "k_kw_spell_ar :=")
     mut rows := Vector {} as Vector<str>
     rows.push("token\tenglish\tpersian\tarabic")
     mut i := 0


### PR DESCRIPTION
`main` cannot cut a release right now: all seven build jobs fail. Two causes so
far, both found by reading the run rather than guessing.

## setup-salam asked for assets that do not exist

The action mapped every non-x64 platform to a `-minimal` archive:

```
Linux-ARM64) asset="salam-${version}-linux-aarch64-minimal.zip"
```

No release has ever published one. I checked v0.3.1, v0.3.0 and v0.2.9: zero
`-minimal` assets between them. So arm64, armhf and i686 lookups have always
404'd, and the moment the release jobs started needing a seed, the aarch64 job
failed on "Install a seed compiler".

It now resolves `salam-<version>-<slug>.zip` and only falls back to `-minimal`
if the tag actually carries one. Simulated all seven platforms against the real
v0.3.1 asset list; every one resolves to a file that exists.

## macOS lost its Homebrew link path

The old `make -C c` line passed `EXTRA_LDFLAGS="-L$(brew --prefix)/lib"`, and my
conversion dropped it, so the link failed with `library 'zstd' not found` - the
merged LLVM archive references zstd and zlib, which live outside the default
search path on macOS. Passed through again.

## What the run also showed working

Worth recording, because it is the part that was uncertain: the whole embedding
pipeline runs correctly in CI. All twelve blobs were built on the Linux job:

```
embedded musl_x86_64 (2856960 bytes)
embedded musl_aarch64 (10250240 bytes)
embedded mingw_x86_64 (14735360 bytes)
embedded hostlibs (19200000 bytes)
embedded extralibs_aarch64_linux_musl (19107840 bytes)
...
```

and the compiler built from them, reaching the smoke test before failing on a
separate issue (the musl sysroot lookup, fixed in the merged PR).

Still to work through: the Windows, Windows-i686, i686-container and
armhf-container jobs. Each fails for its own reason and needs its own read.