### PR TITLE
release: the review was right about the i686 stack

### DIFF
--- a/compiler/cli/cli_api.salam
+++ b/compiler/cli/cli_api.salam
@@ -83,6 +83,7 @@ Build options:
                            (else: $SALAM_STD, sibling salam.cfg,
                             binary-relative, install prefix, then ./std)
   --keep-c                 Keep generated .c/.h files
+  --emit-c                 Emit the generated C and stop (implies --keep-c)
   -dNAME=VALUE             Define a compile-time constant the program can
     (--const=NAME=VALUE)   read by name, as if the source said
                            'const NAME := VALUE' (repeatable). NAME must be

--- a/compiler/cli/cli_parse.salam
+++ b/compiler/cli/cli_parse.salam
@@ -353,7 +353,13 @@ func parse_options(args: Vector<str>, start: int, out &: dr.Dr): bool:
     until i < n:
         arg := args.get(i)
         mut val := ""
-        if str.Equals(arg, "--keep-c"):
+        if str.Equals(arg, "--emit-c"):
+            out.emit_c = true
+            out.keep_c = true
+            if str.Equals(out.backend, "auto"):
+                out.backend = "c"
+            end
+        else str.Equals(arg, "--keep-c"):
             out.keep_c = true
         else str.Equals(arg, "--time-report"):
             out.time_report = true

--- a/compiler/driver/driver.salam
+++ b/compiler/driver/driver.salam
@@ -227,6 +227,10 @@ pub struct Dr:
         // the link step, for archives not installed under the usual prefix.
         pub lib_paths: Vector<str> = Vector {}
         pub keep_c: bool = false
+        // --emit-c: write the generated C and stop, without handing it to a
+        // C compiler. For a foreign --target the host cc cannot build it
+        // anyway, and the caller (build-wasm.sh, emcc) wants the sources.
+        pub emit_c: bool = false
         pub force: bool = false
         pub safe: bool = true
         pub fmt_check: bool = false

--- a/compiler/driver/driver_build.salam
+++ b/compiler/driver/driver_build.salam
@@ -77,7 +77,13 @@ import pf "../prof_self.salam"
         // driver_llvm_build(opt);` - NOT a bare driver_llvm call (that would
         // skip setting llvm_emit from opt->command). LlvmBuild (below, in the
         // public section) is that wrapper.
-        if str.Len(opt.llvm_target) > 0:
+        // ...unless the C backend was asked for by name. `--backend=c
+        // --target=X` then means "emit C conditioned for X", which is how
+        // the wasm build gets browser code: emcc compiles the result, and
+        // without the triple the condcomp table would be built from the
+        // HOST's defines and every SALAM_OS_WASM arm would be pruned away
+        // on a Linux runner.
+        if str.Len(opt.llvm_target) > 0 && !str.Equals(opt.backend, "c"):
             ret LlvmBuild(opt)
         end
 
@@ -379,7 +385,7 @@ import pf "../prof_self.salam"
                 continue
             end
 
-            table := cc.TableBuild("", defs)
+            table := cc.TableBuild(opt.llvm_target, defs)
             modpack := lx.Detect(sf, pack)
             modentry := lp.Entry(modpack)
 
@@ -676,6 +682,12 @@ import pf "../prof_self.salam"
                 end
             end
             ret 1
+        end
+
+        // --emit-c stops here: the sources are on disk and a host C compiler
+        // has no business trying to build them for a foreign target.
+        if opt.emit_c:
+            ret 0
         end
 
         mut crc := 0

--- a/compiler/llvmgen/llvm_api.salam
+++ b/compiler/llvmgen/llvm_api.salam
@@ -517,7 +517,6 @@ pub func RunOpts(
         toplevel(v, s, a, at.Child(a, program, i))
         i += 1
     end
-    linker_options_finalize(v)
     debug_finalize(v)
     if co.SbLen(v.bhg) > (0 as i64):
         out_g(v, "; on-demand runtime helpers\n")

--- a/compiler/llvmgen/llvm_call.salam
+++ b/compiler/llvmgen/llvm_call.salam
@@ -124,13 +124,15 @@ func call_user(v &: Lv, s &: sm.Sema, a &: at.Ast, n: int, nm: str): Llv:
         callty = " " + co.SbCstr(sp)
         co.SbFree(sp)
     end
+    // The convention has to match the `declare` exactly - see StdcallCc.
+    cc := StdcallCc(v, fname)
     if str.Equals(rts, "void"):
-        emit(v, "call void" + callty + " @" + fname + "(" + argsx + ")")
+        emit(v, "call" + cc + " void" + callty + " @" + fname + "(" + argsx + ")")
         ret make_llv("0", "void")
     end
     r := new_tmp(v)
     emit(
-        v, r + " = call " + ty_of(v, s, a, rts) + callty + " @" + fname + "(" + argsx + ")"
+        v, r + " = call" + cc + " " + ty_of(v, s, a, rts) + callty + " @" + fname + "(" + argsx + ")"
     )
     ret make_llv(r, rts)
 end

--- a/compiler/llvmgen/llvm_debug.salam
+++ b/compiler/llvmgen/llvm_debug.salam
@@ -130,26 +130,6 @@ func debug_location(v &: Lv, line: int, col: int): str:
     )
 end
 
-// linker_options_finalize - flushes the -alternatename aliases collected by
-// declare_extern into !llvm.linker.options, which the COFF backend writes
-// into the object's .drectve section for the linker to read.
-//
-// Runs before debug_finalize because that one flushes the metadata buffer
-// these nodes have to already be in.
-func linker_options_finalize(v &: Lv):
-    if v.extern_stdcall.len() == 0:
-        ret
-    end
-    mut ids := ""
-    repeat v.extern_stdcall.len() with i:
-        if i != 0:
-            ids += ", "
-        end
-        ids += meta_add(v, `!{!"` + v.extern_stdcall.get(i) + `"}`)
-    end
-    out_g(v, "\n!llvm.linker.options = !{" + ids + "}\n")
-end
-
 // ll_debug_finalize
 func debug_finalize(v &: Lv):
     // Also the flush point for TBAA nodes, which exist without -g.

--- a/compiler/llvmgen/llvm_globals.salam
+++ b/compiler/llvmgen/llvm_globals.salam
@@ -479,50 +479,25 @@ func body_sig_for(s &: sm.Sema, a &: at.Ast, name: str, owner &: int): int:
     ret 0 - 1
 end
 
-// stdcall_alias_for - the "-alternatename:_F=_F@N" a 32-bit Windows link
-// needs for one extern function, or "" when it needs none.
+// StdcallCc - " x86_stdcallcc" for an extern that is a Win32 API on a
+// 32-bit Windows target, "" otherwise. See k_lv_win32_stdcall in
+// llvmgen.salam for why this is a table and how it was checked.
 //
-// Win32 APIs are stdcall on i386, so kernel32 & co. export them decorated
-// (`_GetFileType@4`, verified with nm on libkernel32.a) while the plain
-// `extern func GetFileType(...)` this compiler emits references the bare
-// `_GetFileType`. On x86_64 there is no decoration and the two coincide,
-// which is why only the 32-bit Windows build ever broke - it stopped with
-// every Win32 import undefined.
-//
-// The alias is emitted for EVERY extern, not just the ones that turn out to
-// be stdcall, because nothing in the source says which is which. That costs
-// nothing: `-alternatename` is consulted only for a symbol that is still
-// undefined once everything has been scanned, so a cdecl extern like fopen
-// resolves normally and its alias is never looked at. It is the same idea
-// as GNU ld's --enable-stdcall-fixup, except it names the exact symbol
-// instead of searching, and unlike that flag it works under lld, which does
-// no stdcall fixup of its own (checked against lld 21 in mingw mode).
-//
-// A variadic extern is cdecl by definition and gets no alias.
-func stdcall_alias_for(v &: Lv, s &: sm.Sema, a &: at.Ast, name: str, sg &: sm.Sig): str:
+// Both the `declare` and every call site have to carry it: the convention
+// decides who pops the arguments, and disagreeing on that is what left the
+// i686 stack eight bytes out after the first Win32 call. Emitting it also
+// makes LLVM's mangler append the @N byte count, which is the decoration
+// kernel32's import library exports the function under.
+func StdcallCc(v &: Lv, name: str): str:
     if !target_is_windows_of(v.triple) || target_ptr_bits_of(v.triple) != 32:
         ret ""
     end
-    if sg.variadic:
-        ret ""
-    end
-    mut bytes := 0
-    repeat sg.params.len() with j:
-        t := ty_of(v, s, a, sm.ToString(s, sg.params.get(j)))
-        if str.Equals(t, "i64") || str.Equals(t, "double"):
-            bytes += 8
-        else str.Equals(t, "ptr") || str.Equals(t, "i32") || str.Equals(t, "i16") || str.Equals(t, "i8") || str.Equals(t, "i1") || str.Equals(t, "float"):
-            // Everything narrower than a word is passed in a whole stack
-            // slot, so it counts as 4.
-            bytes += 4
-        else:
-            // An aggregate passed by value has no simple byte count; rather
-            // than guess a wrong @N, emit no alias at all.
-            ret ""
+    repeat k_lv_win32_stdcall.len() with i:
+        if str.Equals(name, k_lv_win32_stdcall[i]):
+            ret " x86_stdcallcc"
         end
     end
-    dec := "_" + name + "@" + co.I64Toa(bytes as i64)
-    ret "-alternatename:_" + name + "=" + dec
+    ret ""
 end
 
 // ll_declare_extern - one bodyless `extern func` -> one `declare` line,
@@ -556,14 +531,10 @@ func declare_extern(v &: Lv, s &: sm.Sema, a &: at.Ast, name: str, sigid: int):
         ret
     end
     v.extern_names.push(name)
-    alias := stdcall_alias_for(v, s, a, name, sg)
-    if str.Len(alias) > 0:
-        v.extern_stdcall.push(alias)
-    end
     dn2 := at.Get(a, sg.decl)
     mut b := co.SbNew()
     co.SbPuts(
-        b, "declare " + ty_of(v, s, a, sm.ToString(s, sg.ret_type)) + " @" + name + "("
+        b, "declare" + StdcallCc(v, name) + " " + ty_of(v, s, a, sm.ToString(s, sg.ret_type)) + " @" + name + "("
     )
     repeat sg.params.len() with j:
         if j != 0:

--- a/compiler/llvmgen/llvmgen.salam
+++ b/compiler/llvmgen/llvmgen.salam
@@ -219,6 +219,37 @@ k_lv_ints := [
 
 k_lv_uns := ["u8", "u16", "u32", "u64", "size"]
 
+// Win32 APIs are stdcall on i386, and that is not only a name-decoration
+// question: the callee pops the arguments. A call emitted with the default
+// C convention pops them a second time, so the very first GetConsoleMode
+// left ESP eight bytes high and the 32-bit Windows binary walked off its
+// own stack. Marking the declaration and the call x86_stdcallcc fixes the
+// convention, and LLVM's mangler then appends the @N byte count on its own,
+// which is also what makes the symbol match kernel32's _GetConsoleMode@8.
+//
+// A table because nothing in the source says which convention an extern
+// uses, and a `stdcall` keyword could not be used in std until a seed that
+// parses it ships. Every name here was checked against the i686 mingw-w64
+// import libraries with nm: all of them are defined there as _Name@N and
+// none as a bare _Name, so none of them is cdecl. It covers what std
+// declares under SALAM_OS_WINDOWS; anything absent keeps the C convention
+// exactly as before, and a Win32 name that is missing fails loudly at link
+// time as an undefined symbol rather than silently corrupting a stack.
+// CreateCoreWebView2EnvironmentWithOptions is the one entry nm could not
+// confirm - it lives in the WebView2 SDK rather than the mingw import
+// libraries - and it is stdcall by the same Win32 convention.
+k_lv_win32_stdcall := [
+    "CloseHandle", "CreateCoreWebView2EnvironmentWithOptions", "CreateFileA", "CreateProcessA", "CreateWindowExA",
+    "DebugBreak", "DeleteCriticalSection", "DestroyWindow", "DispatchMessageA", "EnterCriticalSection",
+    "FindClose", "FindFirstFileA", "FindNextFileA", "GetConsoleMode", "GetConsoleScreenBufferInfo",
+    "GetCurrentDirectoryA", "GetExitCodeProcess", "GetFileAttributesA", "GetFileAttributesExA", "GetLastError",
+    "GetModuleHandleA", "GetProcAddress", "GetStdHandle", "GetSystemInfo", "GetSystemTimeAsFileTime",
+    "GetTickCount", "InitializeCriticalSection", "IsWindow", "LeaveCriticalSection", "MoveFileExA",
+    "MultiByteToWideChar", "PeekMessageA", "QueryPerformanceCounter", "QueryPerformanceFrequency",
+    "SetConsoleMode", "SetWindowPos", "SetWindowTextA", "Sleep", "SleepEx", "TerminateProcess", "TranslateMessage",
+    "WSAPoll", "WSAStartup"
+]
+
 // ll_extern_seen's prologue[] (codegen_llvm_decl.c), order kept.
 k_lv_prologue_externs := [
     "printf", "dprintf", "strlen", "strcmp", "malloc", "memcpy", "realloc", "free", "memmove", "abort",
@@ -330,9 +361,6 @@ pub struct Lv:
     pub globals: Vector<LvVar> = Vector {}
     pub gdefer: Vector<int> = Vector {} // indices into `globals`
     pub extern_names: Vector<str> = Vector {}
-    // One "-alternatename:_F=_F@N" per extern function, for 32-bit Windows
-    // targets only; empty everywhere else. See stdcall_alias_for.
-    pub extern_stdcall: Vector<str> = Vector {}
     pub pkg_scope: int = 0 // sm ScopeId (0 = C NULL)
     pub emitted: Vector<str> = Vector {}
     pub pkg_touched: Vector<int> = Vector {} // sm SymIds
@@ -478,7 +506,6 @@ func new_lv0(): Lv:
     v.globals = Vector {} as Vector<LvVar>
     v.gdefer = Vector {} as Vector<int>
     v.extern_names = Vector {} as Vector<str>
-    v.extern_stdcall = Vector {} as Vector<str>
     v.emitted = Vector {} as Vector<str>
     v.pkg_touched = Vector {} as Vector<int>
     v.hneed = Vector {} as Vector<bool>
@@ -504,7 +531,6 @@ func free_lv(v &: Lv):
     v.globals.free()
     v.gdefer.free()
     v.extern_names.free()
-    v.extern_stdcall.free()
     v.emitted.free()
     v.pkg_touched.free()
     v.hneed.free()

--- a/std/fs/fs.salam
+++ b/std/fs/fs.salam
@@ -294,10 +294,16 @@ else:
     else:
         // macOS and the BSDs keep readdir: their struct dirent is already
         // 64-bit clean, and each has its own d_name offset.
+        //
+        // Emscripten lands here as well, now that the wasm build passes a
+        // wasm triple: its readdir works over MEMFS, its dirent is 64-bit
+        // clean, and it has no syscall() to reach getdents64 with.
         if SALAM_OS_MAC:
             func _dname_off(): i64: ret 21 end
-        else:
+        else SALAM_OS_BSD:
             func _dname_off(): i64: ret 24 end
+        else:
+            func _dname_off(): i64: ret 19 end
         end
         extern:
             func salam_os_listdir(path: str, out_count: void*): void*:

--- a/tools/bash/build-wasm.sh
+++ b/tools/bash/build-wasm.sh
@@ -79,8 +79,19 @@ echo "staged minified stdlib preload image at $STD_MIN"
 # those exact names: a `func` with a body inside an `extern:` block survives
 # DCE and keeps its unmangled symbol, which is Salam's EMSCRIPTEN_KEEPALIVE.
 rm -rf .salam-build
-"$SALAM" build --backend=c --keep-c compiler/wasm_main.salam \
-    --output=.wasm-build/host-salam --log-level=warn >/dev/null 2>&1 || true
+#
+# --target so the condcomp table is built for wasm rather than for this
+# host. Without it a Linux runner prunes every SALAM_OS_WASM arm and keeps
+# the Linux ones, so os.Platform() answered "linux" in the browser and
+# std/fs compiled in its getdents64 path - which emscripten cannot even
+# link ("wasm-ld: undefined symbol: syscall").
+#
+# --emit-c rather than swallowing a link failure: the old `|| true` hid
+# front-end errors too, and since the driver keeps the C it did manage to
+# generate, a half-emitted source set would sail past the find below and
+# reach emcc looking complete.
+"$SALAM" build --backend=c --emit-c --target=wasm32-unknown-emscripten \
+    compiler/wasm_main.salam --output=.wasm-build/host-salam --log-level=warn
 SRCS=$(find .salam-build -name '*.c' | sort | tr '\n' ' ')
 [ -n "$SRCS" ] || {
     echo "no generated C in .salam-build; the compiler build produced nothing" >&2

--- a/tools/mcp/mcp_docs.salam
+++ b/tools/mcp/mcp_docs.salam
@@ -174,8 +174,8 @@ func _word(pair: str): str:
 end
 
 func _row(en: Vector<str>, fa: Vector<str>, ar: Vector<str>, i: int): str:
-    // The spellings arrive bare now, not as "TK_x<tab>spelling" rows, so the
-    // token column is the English spelling and no splitting is needed.
+    // The spellings arrive bare now, not as "TK_x<tab>spelling" rows, so
+    // there is nothing to split and no token column to fill.
     mut line := en.get(i)
     if i < fa.len(): line = line.concat("\t").concat(fa.get(i)) end
     if i < ar.len(): line = line.concat("\t").concat(ar.get(i)) end
@@ -295,7 +295,12 @@ pub func Keywords(): mcpout.ToolResult:
     fa := _kw_table(src, "k_kw_spell_fa :=")
     ar := _kw_table(src, "k_kw_spell_ar :=")
     mut rows := Vector {} as Vector<str>
-    rows.push("token\tenglish\tpersian\tarabic")
+    // Three columns, not four. The old first column carried the TK_ name,
+    // which came free when this parsed "TK_x<tab>spelling" rows; reading
+    // k_kw_spell_en gives bare spellings and no token name, and leaving the
+    // header at four would have shifted every value one column left - a
+    // reader would have taken persian for english.
+    rows.push("english\tpersian\tarabic")
     mut i := 0
     until i < en.len():
         rows.push(_row(en, fa, ar, i))


### PR DESCRIPTION
Rebuilt on current `main`. The branch previously carried the fifteen commits #1547 already merged, which is where the conflict came from - and merging it as it stood would have reverted #1548 and #1550. What is left is the review feedback, four items, three of them real bugs.

## The stdcall one was the serious one

Resolving `_GetFileType` to `_GetFileType@4` through `-alternatename` made the 32-bit Windows link succeed, but the call was still emitted with the C convention, and stdcall means the **callee** pops the arguments. The assembly showed it:

```
	pushl	$L_.str.208
	pushl	%eax
	calll	_GetConsoleMode
	addl	$8, %esp
```

kernel32's `GetConsoleMode` ends in `ret 8`, so those eight bytes came off twice and the binary walked off its own stack at the first Win32 call. It would have linked, shipped, and crashed - the release job cross-compiles on Linux and never runs the result, so nothing would have caught it there.

The declaration and the call now carry `x86_stdcallcc`, LLVM's mangler appends the `@N` itself, and the `addl` is gone:

```
	pushl	$L_.str.208
	pushl	%eax
	calll	_GetConsoleMode@8
```

The `-alternatename` plumbing is deleted; it was papering over a missing decoration.

Which externs are stdcall comes from a table, because nothing in the source says so and a `stdcall` keyword could not be used in `std` until a seed that parses it ships. Every name in it was checked with `nm` against the i686 mingw-w64 import libraries: 42 of the 43 externs `std` declares under `SALAM_OS_WINDOWS` are defined there as `_Name@N` and none as a bare `_Name`, so none is cdecl. The odd one out is the WebView2 entry point, which is not in those libraries at all and is stdcall by the same convention. `fopen`, `malloc` and `strlen` keep the C convention, and a 64-bit Windows target emits no `x86_stdcallcc` at all.

## The wasm build was compiling browser code as Linux

The C backend passed an empty triple to `TableBuild`, so condcomp used the **host's** defines: a Linux runner pruned every `SALAM_OS_WASM` arm and kept the Linux ones. `os.Platform()` answered `"linux"` in the browser, and `std/fs` compiled in the getdents64 path that emscripten cannot even link (`wasm-ld: undefined symbol: syscall`).

`--backend=c --target=X` now means "emit C conditioned for X" instead of silently rerouting to LLVM, and `build-wasm.sh` passes `wasm32-unknown-emscripten`. Verified: `OS()` folds to `"wasm"` and the generated C mentions `syscall` nowhere. That also retires the `SALAM_NO_SYSCALL` macro this branch was carrying as a stopgap.

## The wasm build was also swallowing front-end errors

`>/dev/null 2>&1 || true` was aimed at an irrelevant host-link failure but hid semantic errors too, and the driver keeps the C it did manage to emit - so a half-generated source set could sail past the non-empty `find` check and reach emcc looking complete. New `--emit-c` writes the C and stops, so there is no host link to forgive. Checked: a bad source now exits 1 with nothing swallowed.

## The keyword table advertised four columns and emitted three

The token column carried the `TK_` name back when this parsed `TK_x<tab>spelling` rows. Reading `k_kw_spell_en` leaves no token name, so the header loses the column rather than repeating english under it - keeping four would have shifted every value one to the left and made persian read as english.

## Verification

Full suite on x86_64: 1399 passed. The failures are four environment ones (no redis server, no websocket port, no libsqlite3 for musl) plus `errors/en/unused_param`, which fails identically with a compiler built from `main` - see the note below. `prek run --all-files` is clean, as are `shellcheck` and `shfmt` on the changed script.

## Separate, not fixed here

`errors/en/unused_param` fails on `main` as well, and it is worth a look on its own: `WasPruned` matches bare names across the whole build, so a parameter named `b` gets no E062 because some condcomp branch somewhere in `std` mentions a `b`. A parameter named `zz_unique_param` in the same file does get it. That silently disables the unused-variable and unused-parameter lints for every common identifier name.