### PR TITLE
release: three the compiler was getting wrong

### DIFF
--- a/.github/workflows/compiler-release.yml
+++ b/.github/workflows/compiler-release.yml
@@ -1392,6 +1392,11 @@ jobs:
           MSYSTEM: MINGW64
           CHERE_INVOKING: '1'
           CCACHE_DIR: 'C:/ccache-win64'
+          # Through the environment rather than expanded into the script:
+          # zizmor flags a ${{ }} inside a run block as a template-injection
+          # site, and it is right that the shell should never see the value
+          # as source text.
+          SEED_PATH: ${{ steps.seed.outputs.salam }}
         run: |
           set -eu
           SR=/tmp/mingw-sr/lib
@@ -1453,7 +1458,7 @@ jobs:
           # is not something an MSYS shell resolves, so `command -v salam`
           # found nothing and the build stopped with "no seed compiler".
           sh tools/bash/build-selfhost.sh \
-            --seed="$(cygpath -u '${{ steps.seed.outputs.salam }}')" \
+            --seed="$(cygpath -u "$SEED_PATH")" \
             --llvm="$GITHUB_WORKSPACE" --embed="$GITHUB_WORKSPACE" \
             --output="$GITHUB_WORKSPACE/salam.exe" \
             -- --cc="$(cygpath -m /tmp/cc-static.bat)"

--- a/.github/workflows/extension-vscode.yml
+++ b/.github/workflows/extension-vscode.yml
@@ -66,9 +66,13 @@ jobs:
       # published build lags it. This is the cheap C build (a few seconds),
       # not the full LLVM one the release workflow does.
       - name: Build the salam compiler from source
+        env:
+          # Same reason as the release workflow: the seed path reaches the
+          # script as an environment value, never as expanded script text.
+          SEED_PATH: ${{ steps.seed.outputs.salam }}
         run: |
           set -eu
-          sh tools/bash/build-selfhost.sh --seed="${{ steps.seed.outputs.salam }}"
+          sh tools/bash/build-selfhost.sh --seed="$SEED_PATH"
           ./salam version
           pwd >> "$GITHUB_PATH"
 

--- a/compiler/ast.salam
+++ b/compiler/ast.salam
@@ -245,6 +245,12 @@ pub struct Ast:
     // elsewhere in the module is excused too), which only ever silences a
     // lint, never accepts a program the checker would otherwise reject.
     pub pruned_names: Vector<str> = Vector {}
+    // The file each pruned_names/pruned_writes entry came from, parallel to
+    // them. Without it a name matched across the whole build: a parameter
+    // called 'b' got no E062 because some condcomp branch in some other file
+    // of std happened to mention a 'b'.
+    pub pruned_files: Vector<str> = Vector {}
+    pub pruned_write_files: Vector<str> = Vector {}
     pub pruned_writes: Vector<str> = Vector {}
 end
 
@@ -332,6 +338,8 @@ pub func FreeAst(a &: Ast):
     end
     a.nodes.free()
     a.pruned_names.free()
+    a.pruned_files.free()
+    a.pruned_write_files.free()
     a.pruned_writes.free()
 end
 
@@ -468,33 +476,53 @@ end
 
 // Records `name` as having been mentioned in code condcomp pruned away, and
 // (with `wrote`) as having been assigned there. See Ast.pruned_names.
-pub func NotePruned(a &: Ast, name: str, wrote: bool):
+pub func NotePruned(a &: Ast, file: str, name: str, wrote: bool):
     if str.Len(name) == 0:
         ret
     end
     mut seen := false
     repeat a.pruned_names.len() with i:
-        if str.Equals(a.pruned_names.get(i), name):
+        if str.Equals(a.pruned_names.get(i), name) && str.Equals(a.pruned_files.get(i), file):
             seen = true
             break
         end
     end
     if !seen:
         a.pruned_names.push(name)
+        a.pruned_files.push(file)
     end
     if !wrote:
         ret
     end
     repeat a.pruned_writes.len() with j:
-        if str.Equals(a.pruned_writes.get(j), name):
+        if str.Equals(a.pruned_writes.get(j), name) && str.Equals(a.pruned_write_files.get(j), file):
             ret
         end
     end
     a.pruned_writes.push(name)
+    a.pruned_write_files.push(file)
 end
 
-// Whether `name` was mentioned anywhere condcomp pruned away.
-pub func WasPruned(a: Ast, name: str): bool:
+// Whether `name` was mentioned in code condcomp pruned out of `file`.
+//
+// Scoped to one file, because that is the scope the lints it guards work
+// in: a variable's uses and a parameter's uses are inside the function that
+// declares them. Matching bare names across the whole build meant one
+// pruned mention of a short name anywhere in std silently switched E059,
+// E062 and E069 off for every symbol of that name in the program.
+pub func WasPruned(a: Ast, file: str, name: str): bool:
+    repeat a.pruned_names.len() with i:
+        if str.Equals(a.pruned_names.get(i), name) && str.Equals(a.pruned_files.get(i), file):
+            ret true
+        end
+    end
+    ret false
+end
+
+// Whether `name` was mentioned in pruned code ANYWHERE in the build. Only
+// E066 wants this: a function can have its single call site in a branch
+// another file folded away, so that lint really is program-wide.
+pub func WasPrunedAnywhere(a: Ast, name: str): bool:
     repeat a.pruned_names.len() with i:
         if str.Equals(a.pruned_names.get(i), name):
             ret true
@@ -503,10 +531,10 @@ pub func WasPruned(a: Ast, name: str): bool:
     ret false
 end
 
-// Whether pruned-away code assigned to `name`.
-pub func WasPrunedWrite(a: Ast, name: str): bool:
+// Whether pruned-away code in `file` assigned to `name`.
+pub func WasPrunedWrite(a: Ast, file: str, name: str): bool:
     repeat a.pruned_writes.len() with i:
-        if str.Equals(a.pruned_writes.get(i), name):
+        if str.Equals(a.pruned_writes.get(i), name) && str.Equals(a.pruned_write_files.get(i), file):
             ret true
         end
     end

--- a/compiler/condcomp.salam
+++ b/compiler/condcomp.salam
@@ -424,10 +424,10 @@ func cc_lvalue_root(a &: at.Ast, id: int): int:
 end
 
 // cc_note_write - records the root of a write target as assigned-in-pruned-code.
-func cc_note_write(a &: at.Ast, target: int):
+func cc_note_write(a &: at.Ast, file: str, target: int):
     r := cc_lvalue_root(a, target)
     if r != 0:
-        at.NotePruned(a, at.Get(a, r).name, true)
+        at.NotePruned(a, file, at.Get(a, r).name, true)
     end
 end
 
@@ -441,39 +441,39 @@ end
 // receiver of a method call, and any bare identifier handed to a call (the
 // callee's `&:` parameters are not known this early, so every argument name
 // is treated as one).
-func cc_note_pruned(a &: at.Ast, id: int):
+func cc_note_pruned(a &: at.Ast, file: str, id: int):
     if id == 0:
         ret
     end
     n := at.Get(a, id)
-    at.NotePruned(a, n.name, false)
+    at.NotePruned(a, file, n.name, false)
     if n.kind == at.AST_ASSIGN || n.kind == at.AST_INCDEC:
-        cc_note_write(a, n.a)
+        cc_note_write(a, file, n.a)
     end
     if n.kind == at.AST_CALL:
         if at.KindOf(a, n.a) == at.AST_MEMBER:
-            cc_note_write(a, at.Get(a, n.a).a)
+            cc_note_write(a, file, at.Get(a, n.a).a)
         end
         repeat at.ChildCount(a, id) with ai:
             arg := at.Child(a, id, ai)
             if arg != 0 && at.KindOf(a, arg) == at.AST_IDENTIFIER:
-                at.NotePruned(a, at.Get(a, arg).name, true)
+                at.NotePruned(a, file, at.Get(a, arg).name, true)
             end
         end
     end
-    cc_note_pruned(a, n.ty)
-    cc_note_pruned(a, n.a)
-    cc_note_pruned(a, n.b)
-    cc_note_pruned(a, n.c)
-    cc_note_pruned(a, n.d)
+    cc_note_pruned(a, file, n.ty)
+    cc_note_pruned(a, file, n.a)
+    cc_note_pruned(a, file, n.b)
+    cc_note_pruned(a, file, n.c)
+    cc_note_pruned(a, file, n.d)
     repeat at.ChildCount(a, id) with i0:
-        cc_note_pruned(a, at.Child(a, id, i0))
+        cc_note_pruned(a, file, at.Child(a, id, i0))
     end
     repeat at.DimCount(a, id) with i1:
-        cc_note_pruned(a, at.Dim(a, id, i1))
+        cc_note_pruned(a, file, at.Dim(a, id, i1))
     end
     repeat at.CaptureCount(a, id) with i2:
-        cc_note_pruned(a, at.Capture(a, id, i2))
+        cc_note_pruned(a, file, at.Capture(a, id, i2))
     end
 end
 
@@ -488,7 +488,7 @@ func cc_resolve_if(
     end
     if r.ok:
         taken := r.bval ? n.b : n.c
-        cc_note_pruned(a, r.bval ? n.c : n.b)
+        cc_note_pruned(a, file, r.bval ? n.c : n.b)
         if taken == 0:
             ret 0
         end

--- a/compiler/llvm_bridge.salam
+++ b/compiler/llvm_bridge.salam
@@ -80,7 +80,8 @@ if SALAM_HAVE_LLVM:
         sysroot: str,
         link_libs: Vector<str>,
         link_kinds: Vector<str>,
-        lib_paths: Vector<str>
+        lib_paths: Vector<str>,
+        err &: str
     ): int:
         mut o := llvm.Options {}
         o.opt_level = opt_level
@@ -98,6 +99,10 @@ if SALAM_HAVE_LLVM:
         if r.ok:
             ret 0
         end
+        // Hand the reason back rather than only a 1. Without this the driver
+        // could say no more than "in-process LLVM step failed", which is
+        // what an armhf cross to Windows reports and nothing else.
+        err = r.error
         ret 1
     end
 else:
@@ -117,7 +122,8 @@ else:
         _sysroot: str,
         _link_libs: Vector<str>,
         _link_kinds: Vector<str>,
-        _lib_paths: Vector<str>
+        _lib_paths: Vector<str>,
+        _err &: str
     ): int:
         ret 0 - 1
     end

--- a/compiler/llvmgen/llvm_api.salam
+++ b/compiler/llvmgen/llvm_api.salam
@@ -363,15 +363,20 @@ pub func NativeRun(lgr: lg.Logger, ll_path: str, opts: Options): int:
     // In-process LLVM/LLD first - no compiler or linker needed on the
     // machine running salam. Returns -1 when this binary has no static
     // LLVM linked in, which falls through to the shell-out path below.
+    mut lberr := ""
     brc := lb.Run(
         ll_path, opts.opt_level, opts.output_mode, opts.output_file,
         opts.target_triple, opts.debug_info, opts.verify_module,
         opts.native_cpu, opts.sysroot, opts.link_libs, opts.link_kinds,
-        opts.lib_paths
+        opts.lib_paths, lberr
     )
     if brc >= 0:
         if brc != 0:
-            lg.Log(lgr, lg.PH_DRIVER, lg.LOG_ERROR, "in-process LLVM step failed")
+            mut msg := "in-process LLVM step failed"
+            if str.Len(lberr) > 0:
+                msg = msg + ": " + lberr
+            end
+            lg.Log(lgr, lg.PH_DRIVER, lg.LOG_ERROR, msg)
         end
         ret brc
     end

--- a/compiler/llvmgen/llvm_type.salam
+++ b/compiler/llvmgen/llvm_type.salam
@@ -515,8 +515,14 @@ func sym_qualified(v &: Lv, s &: sm.Sema, a &: at.Ast, name: str): int:
     ret r
 end
 
-// ll_scan_mangled - find a struct/enum in `sc` by its *mangled* type name
-// ("rawsock_Socket") rather than by its declared name ("Socket").
+// ll_scan_mangled - find a struct/enum/interface in `sc` by its *mangled*
+// type name ("rawsock_Socket") rather than by its declared name ("Socket").
+//
+// Interfaces belong here for the same reason structs do. Leaving them out
+// meant `dyn pkg.Iface` never resolved: the type string reaching call_dyn
+// is the mangled "ifacestore_Store", the scan skipped every SYM_INTERFACE,
+// and the backend gave up with "dynamic call on non-interface" on source
+// the C backend compiles. It cost the whole db/ interface suite.
 func scan_mangled(s &: sm.Sema, sc: int, name: str): int:
     if sc == 0:
         ret 0
@@ -525,7 +531,14 @@ func scan_mangled(s &: sm.Sema, sc: int, name: str): int:
     repeat syms.len() with i:
         sid := syms.get(i)
         sy := sm.SymAt(s, sid)
-        if sy.kind == sm.SYM_STRUCT || sy.kind == sm.SYM_ENUM:
+        if sy.kind == sm.SYM_INTERFACE:
+            // An interface symbol carries no `ty` - sema gives it a
+            // members scope and a pkgname instead - so its mangled name is
+            // rebuilt the way sema_typeres builds it.
+            if str.Len(sy.pkgname) > 0 && str.Equals(sy.pkgname + "_" + sy.name, name):
+                ret sid
+            end
+        else sy.kind == sm.SYM_STRUCT || sy.kind == sm.SYM_ENUM:
             if sy.ty != sm.TYPE_NONE:
                 if str.Equals(sm.ToString(s, sy.ty), name):
                     ret sid

--- a/compiler/llvmgen/llvmgen.salam
+++ b/compiler/llvmgen/llvmgen.salam
@@ -229,25 +229,43 @@ k_lv_uns := ["u8", "u16", "u32", "u64", "size"]
 //
 // A table because nothing in the source says which convention an extern
 // uses, and a `stdcall` keyword could not be used in std until a seed that
-// parses it ships. Every name here was checked against the i686 mingw-w64
-// import libraries with nm: all of them are defined there as _Name@N and
-// none as a bare _Name, so none of them is cdecl. It covers what std
-// declares under SALAM_OS_WINDOWS; anything absent keeps the C convention
-// exactly as before, and a Win32 name that is missing fails loudly at link
-// time as an undefined symbol rather than silently corrupting a stack.
-// CreateCoreWebView2EnvironmentWithOptions is the one entry nm could not
-// confirm - it lives in the WebView2 SDK rather than the mingw import
-// libraries - and it is stdcall by the same Win32 convention.
+// parses it ships.
+//
+// Derived rather than hand-listed, after a hand-listed one shipped without
+// GetFileType and the 32-bit Windows link came back undefined on it: every
+// function name declared anywhere in this tree was tested against the i686
+// mingw-w64 import libraries with nm, and a name is here exactly when they
+// define _Name@N and do NOT define a bare _Name. That is the condition
+// under which the undecorated reference could not link at all, so it is
+// also the condition under which the extern has to be stdcall.
+//
+// It is why the socket calls are on the list. On Windows send, recv,
+// socket and friends come from ws2_32 and are stdcall; on Linux they are
+// cdecl libc. The table is only consulted for a 32-bit Windows target, so
+// both readings stay correct. fopen, malloc and strlen are absent because
+// the import libraries define them undecorated, which is the same test.
+//
+// A missing name fails loudly at link time as an undefined symbol rather
+// than silently corrupting a stack, which is how the first version's gap
+// surfaced. CreateCoreWebView2EnvironmentWithOptions is the one entry nm
+// could not weigh in on - it lives in the WebView2 SDK, not in the mingw
+// import libraries - and it is stdcall by the same Win32 convention.
 k_lv_win32_stdcall := [
-    "CloseHandle", "CreateCoreWebView2EnvironmentWithOptions", "CreateFileA", "CreateProcessA", "CreateWindowExA",
-    "DebugBreak", "DeleteCriticalSection", "DestroyWindow", "DispatchMessageA", "EnterCriticalSection",
-    "FindClose", "FindFirstFileA", "FindNextFileA", "GetConsoleMode", "GetConsoleScreenBufferInfo",
-    "GetCurrentDirectoryA", "GetExitCodeProcess", "GetFileAttributesA", "GetFileAttributesExA", "GetLastError",
-    "GetModuleHandleA", "GetProcAddress", "GetStdHandle", "GetSystemInfo", "GetSystemTimeAsFileTime",
-    "GetTickCount", "InitializeCriticalSection", "IsWindow", "LeaveCriticalSection", "MoveFileExA",
-    "MultiByteToWideChar", "PeekMessageA", "QueryPerformanceCounter", "QueryPerformanceFrequency",
-    "SetConsoleMode", "SetWindowPos", "SetWindowTextA", "Sleep", "SleepEx", "TerminateProcess", "TranslateMessage",
-    "WSAPoll", "WSAStartup"
+    "CertCloseStore", "CertEnumCertificatesInStore", "CertOpenSystemStoreA", "CloseHandle",
+    "CreateCoreWebView2EnvironmentWithOptions", "CreateFileA", "CreateProcessA", "CreateWindowExA", "DebugBreak",
+    "DeleteCriticalSection", "DestroyWindow", "DispatchMessageA", "EnterCriticalSection", "FindClose",
+    "FindFirstFileA", "FindNextFileA", "GetConsoleMode", "GetConsoleScreenBufferInfo", "GetCurrentDirectoryA",
+    "GetCurrentProcess", "GetExitCodeProcess", "GetFileAttributesA", "GetFileAttributesExA", "GetFileType",
+    "GetLastError", "GetModuleHandleA", "GetProcAddress", "GetProcessTimes", "GetStdHandle", "GetSystemInfo",
+    "GetSystemTimeAsFileTime", "GetTickCount", "InitializeCriticalSection", "IsWindow", "LeaveCriticalSection",
+    "MoveFileExA", "MultiByteToWideChar", "PeekMessageA", "QueryPerformanceCounter", "QueryPerformanceFrequency",
+    "ReadConsoleInputA", "SetConsoleMode", "SetWindowPos", "SetWindowTextA", "Sleep", "SleepEx",
+    "TerminateProcess", "TranslateMessage", "WSAPoll", "WSAStartup", "WaitForSingleObject", "WideCharToMultiByte",
+    "WinHttpAddRequestHeaders", "WinHttpCloseHandle", "WinHttpConnect", "WinHttpOpen", "WinHttpOpenRequest",
+    "WinHttpQueryHeaders", "WinHttpReadData", "WinHttpReceiveResponse", "WinHttpSendRequest", "accept", "bind",
+    "closesocket", "connect", "freeaddrinfo", "getaddrinfo", "gethostbyname", "getsockname", "htons", "inet_ntoa",
+    "ioctlsocket", "listen", "ntohs", "poll", "recv", "recvfrom", "send", "sendto", "setsockopt", "shutdown",
+    "socket"
 ]
 
 // ll_extern_seen's prologue[] (codegen_llvm_decl.c), order kept.

--- a/compiler/semantic/sema_check_fn.salam
+++ b/compiler/semantic/sema_check_fn.salam
@@ -340,7 +340,9 @@ func sema_check_unused_funcs(s &: Sema, a &: at.Ast):
         if str.Equals(f2.name, "main") || str.Equals(f2.name, entry):
             continue
         end
-        if at.WasPruned(a, f2.name):
+        // Anywhere, not this file: a function's only call can sit in a
+        // branch some other file folded away.
+        if at.WasPrunedAnywhere(a, f2.name):
             continue
         end
         _sfu := sema_use_decl_file(s, a, f2.decl)

--- a/compiler/semantic/sema_layout.salam
+++ b/compiler/semantic/sema_layout.salam
@@ -341,7 +341,7 @@ func check_unused_params(s &: Sema, a &: at.Ast, sc: int, _fn: int):
     scv := scope_at(s, sc)
     repeat scv.symbols.len() with i:
         p := sym_at(s, scv.symbols.get(i))
-        if p.kind == SYM_PARAM && !p.used && p.decl != 0 && str.Len(p.name) > 0 && byte_at(p.name, 0) != 95 && !at.NameIsErr(p.name) && !str.Equals(p.name, "this") && !at.WasPruned(a, p.name):
+        if p.kind == SYM_PARAM && !p.used && p.decl != 0 && str.Len(p.name) > 0 && byte_at(p.name, 0) != 95 && !at.NameIsErr(p.name) && !str.Equals(p.name, "this") && !at.WasPruned(a, s.file, p.name):
             serr(
                 s, 62, span_of(a, p.decl), co.Format1(
                     i18.Tr("unused parameter '%s' (prefix with '_' if intentional)"), co.ArgStr(p.name)

--- a/compiler/semantic/sema_stmt_lower.salam
+++ b/compiler/semantic/sema_stmt_lower.salam
@@ -45,7 +45,7 @@ func check_unused_loop_bind(s &: Sema, a &: at.Ast, v &: Symbol): bool:
     if !v.loop_bind || v.kind != SYM_VAR || v.decl == 0 || str.Len(v.name) == 0:
         ret false
     end
-    if v.used || str.Equals(v.name, "_") || at.WasPruned(a, v.name):
+    if v.used || str.Equals(v.name, "_") || at.WasPruned(a, s.file, v.name):
         ret true
     end
     serr(
@@ -888,13 +888,13 @@ func sema_check_block(s &: Sema, a &: at.Ast, block: int):
             _skip0 := 0 // name unreadable, already reported by the parser
         else check_unused_loop_bind(s, a, v):
             _skip2 := 0 // reported (or excused) as a loop binding
-        else v.kind == SYM_VAR && !v.used && v.decl != 0 && str.Len(v.name) > 0 && byte_at(v.name, 0) != 95 && !at.WasPruned(a, v.name):
+        else v.kind == SYM_VAR && !v.used && v.decl != 0 && str.Len(v.name) > 0 && byte_at(v.name, 0) != 95 && !at.WasPruned(a, s.file, v.name):
             serr(
                 s, 59, span_of(a, v.decl), co.Format1(
                     i18.Tr("unused variable '%s' (prefix with '_' if intentional)"), co.ArgStr(v.name)
                 )
             )
-        else v.kind == SYM_VAR && v.is_mut && !v.mutated && v.decl != 0 && !at.Get(a, v.decl).synthetic && str.Len(v.name) > 0 && byte_at(v.name, 0) != 95 && !at.WasPrunedWrite(a, v.name):
+        else v.kind == SYM_VAR && v.is_mut && !v.mutated && v.decl != 0 && !at.Get(a, v.decl).synthetic && str.Len(v.name) > 0 && byte_at(v.name, 0) != 95 && !at.WasPrunedWrite(a, s.file, v.name):
             serr(
                 s, 69, span_of(a, v.decl), co.Format1(
                     i18.Tr("variable '%s' is declared 'mut' but never mutated; remove 'mut' or declare it 'const'"),

--- a/tests/en/errors/unused_param_pruned_name.salam
+++ b/tests/en/errors/unused_param_pruned_name.salam
@@ -1,0 +1,30 @@
+/*
+ * Salam Programming Language (2024-2026)
+ *
+ *   +-------------------+
+ *   |     S A L A M     |
+ *   +-------------------+
+ *
+ * Designed by Seyyed Ali Mohammadiyeh and the Salam Team
+ * Born from a decade of language design experience (since 2018)
+ *
+ * Repository: https://github.com/SalamLang/Salam
+ *
+ */
+
+// EXPECT: E062
+// The name deliberately matches one that condcomp prunes away elsewhere in
+// this same build. The pruned-name guard used to match bare names across
+// every file, so one folded branch anywhere in std switched E062 off for
+// every 'b' in the program; a parameter with an unusual name still got it.
+if SALAM_OS_WINDOWS:
+    const _PLATFORM_TAG := "w"
+else:
+    const _PLATFORM_TAG := "u"
+end
+
+func take(a: int, b: int): int:
+    ret a
+end
+
+func main: println take(1, 2) end


### PR DESCRIPTION
Three bugs, each reproduced before it was touched and re-checked after.

## 1. The pruned-name guard matched across the whole build

A parameter called `b` got no E062. One called `zz_unique_param`, in the same file, did:

```
func f(a: int, zz_unique_param: int): int:   ->  E062
func f(a: int, b: int): int:                 ->  (nothing)
```

#1548 added a guard so the unused-symbol lints skip a symbol whose only mention lived in a branch condcomp folded away - right on its own, since that source is fine for the other host. But `WasPruned` looked names up as bare strings over the whole build, and the `Ast` is shared across every file in it. One pruned mention of `b` anywhere in `std` switched E062 off for every `b` in the program, and likewise E059 (unused variable) and E069 (`mut`, never mutated). Short names are the ones that collide, which is to say most of them.

Pruned names now carry the file they came from, and E059/E062/E069 ask for their own file - the scope those lints actually work in, since a variable's uses and a parameter's uses live inside the function that declares them. E066 keeps the program-wide lookup under its own name, `WasPrunedAnywhere`: a function really can have its only call site in a branch another file folded away.

This is what the errors suite and the self-host parity job were failing on (`185 p / 0 f` for the reference compiler against `184 p / 1 f` for the self-hosted one). It reproduces with a compiler built from `main`, so it is not something this branch introduced. The suite now runs 186 / 0, the extra test being a regression test that names its parameter `b` on purpose.

## 2. The stdcall table shipped with holes

The table added in #1549 was hand-listed, and it was missing `GetFileType` - so the 32-bit Windows link came back undefined on it, along with `GetCurrentProcess`, `GetProcessTimes`, `WaitForSingleObject` and `ReadConsoleInputA`. It failed loudly, which is what that design is supposed to do when a name is missing, but hand-listing was the wrong way to build it.

It is derived now: every function name declared anywhere in the tree, tested against the i686 mingw-w64 import libraries with `nm`, kept when they define `_Name@N` and do **not** define a bare `_Name`. That is exactly the condition under which an undecorated reference cannot link, so it is also the condition under which the extern has to be stdcall. 82 names, up from 43.

The new entries include the socket calls, and that is correct rather than incidental: on Windows `send`, `recv` and `socket` come from ws2_32 and are stdcall, while on Linux they are cdecl libc. The table is only consulted for a 32-bit Windows target, so both readings stay right. `fopen`, `malloc` and `strlen` stay off it because the import libraries define them undecorated - the same test, answering the other way.

Compiled the whole compiler for `i686-w64-windows-gnu`: the object has no undecorated Win32 references left.

## 3. `dyn pkg.Iface` never reached codegen

`scan_mangled` resolved mangled type names for structs and enums only, and an interface symbol has no `ty` for it to compare anyway - sema gives it a members scope and a `pkgname` instead. So the type string arriving at `call_dyn`, `ifacestore_Store`, matched nothing and the LLVM backend gave up with `dynamic call on non-interface` on source the C backend compiles happily.

That was 6 of the LLVM gate's codegen failures - the whole `db/` interface suite plus `general/interface_pkg`. The gate's corpus now emits **0** failures over `tests/en`, down from 6, and the `interface_pkg` program built through LLVM prints exactly what the C backend prints, so the vtable dispatch is right and not merely quiet.

## Verification

- LLVM gate corpus over all of `tests/en`: 0 codegen failures (was 6).
- Errors suite: 186 passed / 0 failed (was 184 / 1).
- Full suite on x86_64: 1400 passed. The five failures are environment-only - no redis server, no free websocket port, no `libsqlite3` for the musl cross target - and they fail the same way on `main`.
- `prek run --all-files` clean.