### PR TITLE
release: the embedded sysroot length was a symbol difference

### DIFF
--- a/tools/bash/build-embed.sh
+++ b/tools/bash/build-embed.sh
@@ -107,12 +107,17 @@ done
 # A pointer is 4 bytes on a 32-bit target and 8 on a 64-bit one, and `.quad`
 # against a symbol simply cannot be relocated in a 32-bit object - the i386 and
 # armhf jobs failed with "cannot represent relocation type BFD_RELOC_64". The
-# length stays .quad either way: Salam reads it as an i64, and a difference
-# between two symbols in one section is resolved at assembly time rather than
-# through a relocation. That i64 then needs .balign 8 of its own, because a
-# 4-byte .long pointer ahead of it would otherwise leave it 4-byte aligned -
-# harmless on x86, a fault on armhf, where a 64-bit load wants its natural
-# alignment.
+# length stays .quad either way, because Salam reads it as an i64 - but as a
+# literal count from wc, NOT as `end - data`. A .quad holding a difference of
+# two symbols came out with its low word right and 0xffffffff in its high
+# word on armhf, so the mingw sysroot reported a length of -4279074816 and
+# never unpacked; the musl one survived only because its data symbol sits at
+# offset 0, which makes the difference degenerate. The script already knows
+# the byte count, so nothing has to be relocated or folded at all.
+#
+# The i64 still needs .balign 8 of its own, because a 4-byte .long pointer
+# ahead of it would otherwise leave it 4-byte aligned - harmless on x86, a
+# fault on armhf, where a 64-bit load wants its natural alignment.
 case "$($CC -dumpmachine 2>/dev/null)" in
 i?86-* | arm-* | armv7*-* | armhf-* | powerpc-* | mips-* | mipsel-*) PTR=.long ;;
 *) PTR=.quad ;;
@@ -144,6 +149,7 @@ emit() {
     dir=$2
     if [ -n "$dir" ] && [ -d "$dir" ]; then
         tar cf "$WORK/$stem.tar" -C "$dir" .
+        bytes=$(wc -c <"$WORK/$stem.tar" | tr -d ' ')
         {
             printf '.section .rodata\n'
             printf '%s_data:\n' "$stem"
@@ -155,7 +161,7 @@ emit() {
             printf 'salam_embed_%s_ptr: %s %s_data\n' "$stem" "$PTR" "$stem"
             printf '.balign 8\n'
             printf '.globl salam_embed_%s_len\n' "$stem"
-            printf 'salam_embed_%s_len: .quad %s_end - %s_data\n' "$stem" "$stem" "$stem"
+            printf 'salam_embed_%s_len: .quad %s\n' "$stem" "$bytes"
         } >>"$S"
         echo "  embedded $stem ($(wc -c <"$WORK/$stem.tar") bytes) from $dir"
         staged=$((staged + 1))


### PR DESCRIPTION
armhf built a working compiler, ran it, cross-compiled to `x86_64-linux-musl` - and then failed the Windows cross with

```
in-process LLVM step failed: no mingw sysroot for 'x86_64-w64-windows-gnu'
(looked in /usr/x86_64-w64-mingw32): install mingw-w64 or bundle a sysroot
```

even though the same job had just embedded a 15 MB one:

```
embedded mingw_x86_64 (15892480 bytes) from /work/sysroots/x86_64-w64-mingw32
```

## What was wrong

Each blob's length is a `.quad`, and it held `end - data`. On armhf the assembler wrote the low word correctly and `0xffffffff` into the high word. Straight out of the object, `.data` at 0x40 - musl's length first, then mingw's:

```
0040 00782800 00000000 0080f200 ffffffff
     ^ musl  = 0x00287800 = 2652160     ^ mingw = 0xffffffff00f28000
```

So the compiler read the mingw length as `-4279074816`, tripped the `tar_len < 512` guard in `MaterializeSysroot`, never unpacked the blob, and fell through to the system path - which in an `arm32v7/debian` container has no mingw on it.

The musl blob survived only because its data symbol sits at offset 0, which makes `end - data` degenerate into a plain offset. That is why the musl cross succeeded in the same run and kept this hidden.

Confirmed by reading the values back through the real externs on armhf under QEMU:

```
musl len  = 2652160
mingw len = -4279074816     <- before
mingw len = 15892480        <- after
```

## The fix

`build-embed.sh` already knows each tar's byte count from `wc -c`, so the length is emitted as that literal. Nothing is folded or relocated, on any architecture.

Verified on armhf and on x86_64: both now read 15892480, where armhf read a negative number before. `prek run --all-files` is clean.

Found because #1552 made the in-process LLVM step report its reason instead of one blank sentence - the message quoted at the top did not exist before that.