### PR TITLE
release: two the release gate found and PRs never run

### DIFF
--- a/compiler/driver/driver_api_llvm.salam
+++ b/compiler/driver/driver_api_llvm.salam
@@ -17,6 +17,33 @@ import co "../sal_core.salam"
 import pf "../prof_self.salam"
 import lv "../llvmgen/llvmgen.salam"
 
+// native_link_triple - the triple a build with NO --target actually links
+// for, but only where that link needs a sysroot to succeed.
+//
+// On Windows the native path goes through LinkMingw, which wants the same
+// x86_64-w64-mingw32 tree a cross build does. The sysroot lookup below used
+// to run only when --target was given, so a native Windows build never
+// resolved one - not the bundled tree, not the one compiled into the binary
+// - and LinkMingw fell back to the hardcoded /usr/x86_64-w64-mingw32, which
+// does not exist on Windows. Every file then failed the in-process LLVM
+// step and quietly fell back to the C backend, so a self-contained
+// salam.exe was shipping with LLVM and LLD embedded and never using them.
+// It only became visible when a test needed something tcc cannot compile.
+//
+// Empty everywhere else: those hosts link natively without a sysroot, and
+// an empty triple skips the lookup exactly as before.
+if SALAM_OS_WINDOWS:
+    if SALAM_ARCH_X86:
+        func native_link_triple(): str: ret "i686-w64-windows-gnu" end
+    else SALAM_ARCH_ARM64:
+        func native_link_triple(): str: ret "aarch64-w64-windows-gnu" end
+    else:
+        func native_link_triple(): str: ret "x86_64-w64-windows-gnu" end
+    end
+else:
+    func native_link_triple(): str: ret "" end
+end
+
     // driver_llvm (driver/llvm_build.c) - single-file lex/parse/prune/sema ->
     // lv.RunOpts (IR text) -> write <module>.ll -> lv.NativeRun (the toolchain
     // shell-out; see llvm.salam's stage-C notes on why NativeRun, not a direct
@@ -125,9 +152,13 @@ import lv "../llvmgen/llvmgen.salam"
             o.link_libs = links
             o.link_kinds = kinds
             o.nlink = links.len()
-            if str.Len(opt.llvm_target) > 0:
+            mut sr_triple := opt.llvm_target
+            if str.Len(sr_triple) == 0:
+                sr_triple = native_link_triple()
+            end
+            if str.Len(sr_triple) > 0:
                 mut sr := ""
-                if sm.FindSysroot(opt.llvm_target, sr):
+                if sm.FindSysroot(sr_triple, sr):
                     o.sysroot = sr
                     lg.Log(lgr, lg.PH_DRIVER, lg.LOG_INFO, "using bundled sysroot: " + sr)
                 else:
@@ -136,7 +167,7 @@ import lv "../llvmgen/llvmgen.salam"
                     // that. Deliberately last, so $SALAM_SYSROOTS or a system
                     // package still wins over the embedded copy.
                     mut esr := ""
-                    if EmbeddedSysrootFor(opt.llvm_target, sm.SysrootSubdir(opt.llvm_target), esr):
+                    if EmbeddedSysrootFor(sr_triple, sm.SysrootSubdir(sr_triple), esr):
                         o.sysroot = esr
                         lg.Log(lgr, lg.PH_DRIVER, lg.LOG_INFO, "using embedded sysroot: " + esr)
                     end

--- a/compiler/semantic/sema_imports.salam
+++ b/compiler/semantic/sema_imports.salam
@@ -58,6 +58,30 @@ func norm_ident(s0: str): str:
     ret out
 end
 
+// pkg_decl_offset - where the `package` DECLARATION starts, i.e. the first
+// "package " that begins a line, or the length when there is none.
+//
+// The header scan below stops here, and it used to stop at the first
+// "package " anywhere in the text - which a comment can contain. std/db's
+// header says "A driver still exposes its own package (db.sqlite, ...)" on
+// line 17, twenty-eight lines above the declaration, so the scan gave up
+// before ever reaching the @en/@fa/@ar block and `db` went into no index at
+// all. `import دیتابیس.ردیس` then could not resolve and both the Persian
+// and Arabic redis demos failed to build, on every platform. Four other
+// packages sit on the same trap: arabic, text, unicode and llvm.
+func pkg_decl_offset(txt: str, n: int): int:
+    mut i := 0
+    until i < n:
+        if i == 0 || byte_at(txt, i - 1) == 10:
+            if i + 8 <= n && str.StartsWith(str.Substr(txt, i, 8), "package "):
+                ret i
+            end
+        end
+        i += 1
+    end
+    ret n
+end
+
 // index_pkg_file - scans a std package file's pre-`package` header for
 // @en/@fa/@ar "alias" annotations and records (lang, alias, canon) rows.
 func index_pkg_file(path: str, canon: str):
@@ -67,10 +91,7 @@ func index_pkg_file(path: str, canon: str):
     end
     txt := sf.text
     n := sf.len
-    mut limit := str.IndexOf(txt, "package ")
-    if limit < 0:
-        limit = n
-    end
+    limit := pkg_decl_offset(txt, n)
     mut i := 0
     until i + 4 < limit && g_sm_seg_n < K_SM_SEG_MAX:
         if byte_at(txt, i) != 64:


### PR DESCRIPTION
The full test gate only runs on a `release:` head commit, so both of these sat on `main` until a merge commit walked into them. They are the two failures on [the current `main` release run](https://github.com/SalamLang/Salam/actions/runs/32454303567).

## `import دیتابیس.ردیس` did not resolve

Nor did the Arabic spelling, so both redis demos failed to build - on Linux and on Windows:

```
E008: standard library package 'دیتابیس.ردیس' not found
E001: unknown identifier 'ردیس'   (x14)
```

The alias index scans a package file's header for `@en`/`@fa`/`@ar` and stops at the first `"package "` in the text. Any text - including a comment. `std/db/db.salam` line 17 reads

```
// A driver still exposes its own package (db.sqlite, db.postgres, db.mysql)
```

twenty-eight lines above `package db`, so the scan gave up before it ever reached the annotation block and `db` went into the index under no name at all. The English `import db.redis` still worked because that path does not need the index.

It stops at a `"package "` that begins a line now. Four other packages sit on the same trap and were equally unreachable by their translated names:

| package | `"package "` in a comment | declaration |
| --- | --- | --- |
| `std/arabic` | line 17 | line 44 |
| `std/text` | line 18 | line 24 |
| `std/unicode` | line 18 | line 35 |
| `std/llvm` | line 17 | line 23 |
| `std/db` | line 17 | line 45 |

## Windows was shipping an embedded LLVM it never used

```
in-process LLVM step failed: no mingw sysroot for 'x86_64-w64-windows-gnu'
(looked in /usr/x86_64-w64-mingw32)
salam: falling back to the C backend for this file
.salam-build/salam_mod_atomic_shadow.c:22: error: implicit declaration of function '__atomic_store_n'
```

The sysroot lookup ran only when `--target` was given. A native Windows build gave none, so it resolved neither the bundled tree nor the one compiled into the binary - and `LinkMingw` fell back to a hardcoded `/usr/x86_64-w64-mingw32`, which does not exist on Windows. Every file failed the in-process LLVM step and quietly fell back to the C backend, which is why the job still passed: the bundled tcc compiled everything else fine. It only surfaced on `general/en/atomic_shadow`, the one test needing `__atomic_store_n`, which tcc does not have.

So the Windows release asset carried LLVM and LLD embedded and never reached them. A build with no `--target` now resolves the sysroot for the triple it actually links for. That triple is empty on hosts which link natively without a sysroot, so the lookup is skipped exactly as before off Windows.

Both of these were invisible until #1552 made the in-process LLVM step report its reason instead of one blank sentence.

## Verification

- All three redis demos build; `interop` suite 15/15.
- Full suite on x86_64: 1402 passed. The two failures are a port already bound on this machine (`:8080` is held by another process here), not code.
- `prek run --all-files` clean.
- The Windows half cannot be checked from a PR, since the gate is `release:`-only - so this branch was run through the gate directly with a `workflow_dispatch` nightly build before merging.