### PR TITLE
repl: two the Windows build caught and no Linux run could

### DIFF
--- a/compiler/repl.salam
+++ b/compiler/repl.salam
@@ -1175,15 +1175,16 @@ end
 func exit_note(rc: int): str:
     if SALAM_OS_WINDOWS:
         ret "[program exited with " + co.I64Toa(rc as i64) + "]"
+    else:
+        if rc < 0:
+            ret "[could not run the program]"
+        end
+        sig := rc & 127
+        if sig != 0:
+            ret "[program killed by signal " + co.I64Toa(sig as i64) + "]"
+        end
+        ret "[program exited with " + co.I64Toa(((rc / 256) & 255) as i64) + "]"
     end
-    if rc < 0:
-        ret "[could not run the program]"
-    end
-    sig := rc & 127
-    if sig != 0:
-        ret "[program killed by signal " + co.I64Toa(sig as i64) + "]"
-    end
-    ret "[program exited with " + co.I64Toa(((rc / 256) & 255) as i64) + "]"
 end
 
 // repl_emit_output - prints what this run added. Everything the session
@@ -1241,11 +1242,13 @@ func exec_session(opt &: dr.Dr, full_src: str, replay: bool): int:
     if rc == 0:
         exe := str.Len(opt.exe_path) > 0 ? opt.exe_path : tmp_exe
         mut cmdb := str.NewBuilder()
-        if SALAM_OS_WINDOWS && replay:
+        if SALAM_OS_WINDOWS:
             // cmd.exe strips the outermost quote pair off everything after
             // /c, so the whole redirected command needs one more pair
             // around it for a temp path with a space in it to survive.
-            str.BufAppendChar(cmdb, 34)
+            if replay:
+                str.BufAppendChar(cmdb, 34)
+            end
         end
         str.BufAppendChar(cmdb, 34)
         if SALAM_OS_WINDOWS:


### PR DESCRIPTION
### 📝 Description

The Windows jobs on `main` have been failing since #1556 with two front-end
errors in `compiler/repl.salam`. Both are shapes condcomp folds differently
per target, so no Linux or macOS run could have reported them.

```
error[E070]: unreachable code: the previous statement always exits this block
 --> compiler/repl.salam:1179:8
error[E001]: unknown identifier 'SALAM_OS_WINDOWS'
 --> compiler/repl.salam:1244:12
```

### 📦 Proposed Changes

- `exit_note` put the Windows answer under a bare `if SALAM_OS_WINDOWS:` and
  let the POSIX decoding fall through after it. On a Windows target that fold
  is always-true, so the `ret` inside always exits and the rest is
  unreachable. An `else` arm says the same thing and prunes cleanly on both.
- `if SALAM_OS_WINDOWS && replay:` was the only compound platform test in the
  tree, and this is why: the fold only rewrites a bare marker, so on Windows
  the block survives with `SALAM_OS_WINDOWS` still in it as an identifier
  sema has never heard of. Nesting the two tests is the shape every other
  platform branch here uses.

### 🧪 How Was This Tested?

Built the compiler for both Windows targets - the errors reproduce before
this change and neither reports anything after:

```sh
salam build compiler/main.salam --target=x86_64-windows-gnu --backend=c --keep-c
salam build compiler/main.salam --target=i686-windows-gnu   --backend=c --keep-c
```

Linux unaffected: `general` + `exec` 341 passed / 0 failed, and the `repl`
section 3/3.

### ✅ Checklist

- [x] I have tested these changes locally.
- [x] My code follows the project's coding style guidelines.
- [x] I have reviewed my own code to ensure quality.
- [x] Unnecessary comments and debug code have been removed.