### PR TITLE
leak budget: five new stdlib packages, not a new leak

### DIFF
--- a/compiler/repl.salam
+++ b/compiler/repl.salam
@@ -1175,15 +1175,16 @@ end
 func exit_note(rc: int): str:
     if SALAM_OS_WINDOWS:
         ret "[program exited with " + co.I64Toa(rc as i64) + "]"
+    else:
+        if rc < 0:
+            ret "[could not run the program]"
+        end
+        sig := rc & 127
+        if sig != 0:
+            ret "[program killed by signal " + co.I64Toa(sig as i64) + "]"
+        end
+        ret "[program exited with " + co.I64Toa(((rc / 256) & 255) as i64) + "]"
     end
-    if rc < 0:
-        ret "[could not run the program]"
-    end
-    sig := rc & 127
-    if sig != 0:
-        ret "[program killed by signal " + co.I64Toa(sig as i64) + "]"
-    end
-    ret "[program exited with " + co.I64Toa(((rc / 256) & 255) as i64) + "]"
 end
 
 // repl_emit_output - prints what this run added. Everything the session
@@ -1241,11 +1242,13 @@ func exec_session(opt &: dr.Dr, full_src: str, replay: bool): int:
     if rc == 0:
         exe := str.Len(opt.exe_path) > 0 ? opt.exe_path : tmp_exe
         mut cmdb := str.NewBuilder()
-        if SALAM_OS_WINDOWS && replay:
+        if SALAM_OS_WINDOWS:
             // cmd.exe strips the outermost quote pair off everything after
             // /c, so the whole redirected command needs one more pair
             // around it for a temp path with a space in it to survive.
-            str.BufAppendChar(cmdb, 34)
+            if replay:
+                str.BufAppendChar(cmdb, 34)
+            end
         end
         str.BufAppendChar(cmdb, 34)
         if SALAM_OS_WINDOWS:

--- a/compiler/tools/selfhost-leak-budget.txt
+++ b/compiler/tools/selfhost-leak-budget.txt
@@ -92,9 +92,30 @@
 # regression from std/ getting bigger. If these numbers need raising again,
 # check the token counts first, the same way this entry did.
 
+# Re-baselined 2026-08-21 on Linux/x86-64, gcc 13 (observed: version 6179,
+# help 6167, format 6431, inspect 221689, exec 226231, build 937000; the CI
+# runner saw 221855 / 226227). Only inspect and exec moved, and by 0.8% each -
+# the same shape as the entry above, checked the same way rather than assumed.
+#
+# One ASan binary, two stdlib trees, nothing else different:
+#
+#   case      pre-merge std/   this std/    delta
+#   inspect   219,939          221,772      +1,833
+#   exec      224,481          226,231      +1,750
+#
+# The deltas are the whole overage (the budgets were 220,000 and 224,500, and
+# the pre-merge numbers sit right on them), so the compiler is not leaking
+# more per unit of work - there is more work. std/ gained five packages in
+# 0.3.2 (aws, google, webpush, net/httpx, net/http/swagger), 599 -> 614
+# package files, and the std index scan reads every one of their headers to
+# build the import alias table. More files scanned, more allocations, flat
+# per file.
+#
+# Raised by ~2%, the headroom this file has always carried.
+
 version 6300
 help 6300
 format 6500
-inspect 220000
-exec 224500
+inspect 226500
+exec 231000
 build 946000


### PR DESCRIPTION
### 📝 Description

`inspect` and `exec` went ~0.8% over the self-host leak budget after #1556,
failing the Memory Leaks job on `main`.

The budget file's own header says the ratchet cannot tell a real regression
from `std/` getting bigger, and to check the workload first. So I did, the
same way its 2026-08-18 entry did.

### 📦 Proposed Changes

One ASan binary, two stdlib trees, nothing else different:

| case | pre-merge `std/` | this `std/` | delta |
|---|---|---|---|
| inspect | 219,939 | 221,772 | +1,833 |
| exec | 224,481 | 226,231 | +1,750 |

The deltas are the *entire* overage (budgets were 220,000 and 224,500, and
the pre-merge numbers sit right on them), so the compiler is not leaking
more per unit of work — there is more work. `std/` gained five packages in
0.3.2 (`aws`, `google`, `webpush`, `net/httpx`, `net/http/swagger`),
599 → 614 package files, and the std index scan reads every package header
to build the import alias table.

Raised by ~2%, the headroom this file has always carried. The other four
cases are untouched and still within budget.

### 🧪 How Was This Tested?

```sh
salam build compiler/main.salam --output=salam-asan --cc=gcc --asan
sh compiler/tools/bash/leakcheck-selfhost.sh ./salam-asan
```

```
  version           200685 B     6179 allocs   within budget 6300
  help              200113 B     6167 allocs   within budget 6300
  format            207221 B     6431 allocs   within budget 6500
  inspect          3780691 B   221689 allocs   within budget 226500
  exec             3930819 B   226231 allocs   within budget 231000
  build           10751481 B   937000 allocs   within budget 946000
leakcheck-selfhost: OK
```

### ✅ Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed my own code to ensure quality.
- [x] Documentation has been updated (the budget file documents its own re-baseline).