### PR TITLE
tests: give a repl session the time a full run costs it

### DIFF
--- a/tools/bash/run-tests.sh
+++ b/tools/bash/run-tests.sh
@@ -85,7 +85,11 @@ if [ "${1:-}" = "--worker" ]; then
         # and runs the session from there, and :save writes there too.
         jobdir="$WORK/repljob_${jobid}_$$"
         mkdir -p "$jobdir"
-        got=$( (cd "$jobdir" && tmo "${SALAM_TEST_TIMEOUT:-180}" "$SALAM_ABS" cli --lang="$lang" --no-color --log-level=error <"$fabs" 2>&1) | tr -d '\r')
+        # 600s, not the 180 this started with: every turn of a session shells
+        # out to a whole build, and eight workers compiling at once stretch
+        # each of those. At 180 the section passed when run alone and timed
+        # out inside a full run.
+        got=$( (cd "$jobdir" && tmo "${SALAM_TEST_TIMEOUT:-600}" "$SALAM_ABS" cli --lang="$lang" --no-color --log-level=error <"$fabs" 2>&1) | tr -d '\r')
         rm -rf "$jobdir"
         wk_check "$expabs" "$got"
     }


### PR DESCRIPTION
Each turn of a REPL test builds and runs the whole session, so three sessions against eight workers all compiling at once do not fit in 180 seconds: the `repl` section passed when run on its own and timed out inside a full suite run.

Raises that one job's default to 600s. `SALAM_TEST_TIMEOUT` still overrides it.

Verified: `run-tests.sh` full run on this tree is 1404 passed, 2 failed, 19 skipped - the two failures are `apps/en/websocket_{echo,commands}`, which need ports 8080/8090 that are occupied on this host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)