### PR TITLE
repl: give the LLVM backend the file the turn just wrote

### DIFF
--- a/compiler/driver/driver_build.salam
+++ b/compiler/driver/driver_build.salam
@@ -73,6 +73,19 @@ import pf "../prof_self.salam"
             opt.input = first
         end
 
+        // The two backends read the input from different fields of the same
+        // `opt`: the C path walks `inputs`, the LLVM path reads the single
+        // `input`. The CLI fills both, so the split never shows up there -
+        // but a caller that builds an `opt` by hand (repl.salam's
+        // exec_session, which swaps in a temp file per turn) filled only
+        // `inputs`, and every REPL turn on an LLVM-capable build answered
+        // "salam: no input file". Put them back in step here, which every
+        // build passes through, rather than trusting each caller to know
+        // which field its backend will look at.
+        if str.Len(opt.input) == 0 && opt.inputs.len() > 0:
+            opt.input = opt.inputs.get(0)
+        end
+
         // driver/build.c: `if (opt->llvm_target && opt->llvm_target[0]) return
         // driver_llvm_build(opt);` - NOT a bare driver_llvm call (that would
         // skip setting llvm_emit from opt->command). LlvmBuild (below, in the

--- a/compiler/repl.salam
+++ b/compiler/repl.salam
@@ -1235,6 +1235,10 @@ func exec_session(opt &: dr.Dr, full_src: str, replay: bool): int:
     end
     opt.inputs = Vector {} as Vector<str>
     opt.inputs.push(tmp_src)
+    // Both fields, not just the list: this turn's file is the whole input,
+    // and dr.Build hands `input` to the LLVM backend and `inputs` to the C
+    // one.
+    opt.input = tmp_src
     opt.output = tmp_exe
     opt.exe_path = ""
     opt.keep_c = false

--- a/compiler/tests_port/driver_test.salam
+++ b/compiler/tests_port/driver_test.salam
@@ -154,6 +154,25 @@ func test_build_missing_input():
     testing.AssertTrue(rc != 0)
 end
 
+// Build() reads the input list, but the LLVM backend it dispatches to reads
+// the single opt.input instead. A caller that fills only the list - which
+// repl.salam does, swapping in a fresh temp file every turn - used to reach
+// that backend with nothing to compile and got "salam: no input file" on
+// any binary with LLVM linked in. Build has to put the two back in step,
+// and it has to do so before it can fail on the file itself.
+func test_build_syncs_input_with_inputs():
+    mut opt := dr.NewOptions()
+    defer opt.inputs.free()
+    defer opt.run_args.free()
+    defer opt.defines.free()
+    missing := "this_file_does_not_exist_24680.salam"
+    opt.inputs.push(missing)
+    opt.output = "/tmp/salam_driver_test_sync_out"
+    rc := dr.Build(opt)
+    testing.AssertTrue(rc != 0)
+    testing.AssertEqStr(opt.input, missing)
+end
+
 // Exec() with a nonexistent input also fails cleanly (rc == 2, matching
 // driver_interp's "cannot read source file" -> exit 2).
 func test_exec_missing_input():
@@ -419,6 +438,7 @@ func main:
     test_exe_name()
     test_resolve_color()
     test_build_missing_input()
+    test_build_syncs_input_with_inputs()
     test_exec_missing_input()
     test_backends_report_failure_on_no_input()
     test_llvm_real_program()


### PR DESCRIPTION
`repl/en/redefine`, `repl/en/session` and `repl/en/statements` fail on the Linux release job with

```
[2026-08-21 16:22:32][DRIVER][ERROR] salam: no input file
```

wherever a turn should have printed something, and then `error[E001]: unknown identifier 'n'` on the turn after, because the failed turn also threw away the statement it was about to keep. One cause for both.

**What happens.** `exec_session` writes the session to a temp `.salam` and calls `dr.Build`. It set `opt.inputs` and left `opt.input` empty. The C backend walks `inputs`, so it never noticed; `Llvm()` reads the single `input` and reports "no input file". The release binary has in-process LLVM, so `use_llvm_backend()` picks that path for every turn — and a local build without LLVM picks the C path, which is why this passes here and on every PR.

Reproduces on any build with `salam cli --backend=llvm`:

```
salam> [DRIVER][ERROR] salam: no input file
salam> error[E001]: unknown identifier 'n'
```

**The fix.** `build_impl` fills `opt.input` from the head of `opt.inputs` when a caller left it empty, so the two agree at the point where the backend is chosen rather than in each caller; the REPL sets both anyway. A driver unit test pins the invariant.

**Checked** with a compiler built from this branch: all three REPL sessions match the expected output byte for byte on the default backend *and* under `--backend=llvm`, driver unit tests are 98/98, and repl + general + stdlib are 469/469.

Note this needs [#1563](https://github.com/SalamLang/Salam/pull/1563) too before the release gate is green — that one is the Windows `E086` in `std/net`.