### PR TITLE
Fix typo in SKILL.md about URL's path

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -836,7 +836,7 @@ DialWSSUnverified`, `SendText SendBinary SendBinaryBytes Ping Close Stop`,
   them), Socket.IO v5 on top.
   - **Connecting**: `Dial(url)` / `DialWith(url, opts)`, or `NewManager` +
     `Open` + `Of(m, "/nsp")` for several namespaces multiplexed on one
-    connection. `Connect Disconnect Close CloseManager`. The URL's path is
+    connection. `Connect Disconnect Close CloseManager`. The URLs path is
     the NAMESPACE, not a resource; the HTTP path is `Options.path`
     (default `/socket.io`) and must match the server's.
   - **Sending**: `Emit EmitStr EmitInt EmitFloat EmitBool EmitJSON


### PR DESCRIPTION
Corrected a typo regarding the URL's path in the documentation.

### 📝 Description

Please include a brief description of the changes introduced by this pull request.

### 🔗 Related Issue

If this pull request addresses or resolves an existing issue, please reference it here (e.g. `Closes #123`).

### 📦 Proposed Changes

Outline the changes made in this pull request and explain their purpose.

- <!-- change 1 -->
- <!-- change 2 -->

### 🧪 How Was This Tested?

Describe how you tested your changes. Include relevant commands, test files, or screenshots.

```sh
# example
salam build my-change.salam --output=test
./test
```

### ✅ Checklist

- [ ] I have tested these changes locally.
- [ ] My code follows the project's coding style guidelines (see [CONTRIBUTING.md](CONTRIBUTING.md)).
- [ ] C code has been formatted with `clang-format` (if applicable).
- [ ] I have reviewed my own code to ensure quality.
- [ ] Unnecessary comments and debug code have been removed.
- [ ] Documentation has been updated (if applicable).
- [ ] New tests have been added or existing tests updated (if applicable).

### 💬 Additional Notes

Add any additional notes, context, or screenshots about this pull request.

---

> 🙏 Thank you for contributing to Salam (سلام)! Every contribution brings us closer to making programming accessible to everyone.
