### PR TITLE
lexer: slice tokens without re-measuring the whole file

### DIFF
--- a/compiler/lexer/lexer_cursor.salam
+++ b/compiler/lexer/lexer_cursor.salam
@@ -49,8 +49,13 @@ func advc(L &: Lx): int:
 end
 
 // lx_slice (arena_strndup -> substr copy)
+// SubstrIn, not substr: `start` and `L.pos` are both cursor positions, so
+// the slice is inside L.s by construction and substr's clamp would only
+// re-measure the whole file - once per token, which is what made lexing a
+// stdlib package quadratic in its size (81% of a playground compile was
+// strlen underneath this one line).
 func lex_slice(L &: Lx, start: int): str:
-    ret L.s.substr(start, L.pos - start)
+    ret str.SubstrIn(L.s, start, L.pos - start)
 end
 
 // lx_match ("match" is a Salam keyword)

--- a/compiler/lexer/lexer_layout.salam
+++ b/compiler/lexer/lexer_layout.salam
@@ -117,7 +117,7 @@ func layout_try_end_inline(L &: Lx, b: co.SrcPos): bool:
     klen := end_kw.len()
     mut matched_kw := ""
     mut matched_len := 0
-    if L.pos + klen <= L.n && str.Equals(L.s.substr(L.pos, klen), end_kw):
+    if L.pos + klen <= L.n && str.Equals(str.SubstrIn(L.s, L.pos, klen), end_kw):
         after := peek2(L, klen)
         if after == 32 || after == 9 || after == 13 || after == 10 || after == 0:
             matched_kw = end_kw
@@ -175,7 +175,7 @@ func layout_name(L &: Lx):
     end
     stop := trim_ws_end(L.s, start, L.pos)
     namelen := stop - start
-    name := L.s.substr(start, namelen)
+    name := str.SubstrIn(L.s, start, namelen)
     term := peek(L)
     if namelen == 0:
         if term == 58:

--- a/compiler/lexer/lexer_string.salam
+++ b/compiler/lexer/lexer_string.salam
@@ -129,7 +129,7 @@ func scan_utf8_char(L &: Lx):
         bytes = decode_string(text.substr(1, text.len() - 1), false)
         nbytes = bytes.len()
     else:
-        bytes = L.s.substr(content_start, content_len)
+        bytes = str.SubstrIn(L.s, content_start, content_len)
         nbytes = content_len
     end
     if nbytes == 0:

--- a/compiler/lexer/lexer_trivia.salam
+++ b/compiler/lexer/lexer_trivia.salam
@@ -42,7 +42,7 @@ func try_line_comment(L &: Lx): bool:
     skip_to_eol(L)
     if L.keep_comments:
         stop := trim_ws_end(L.s, start, L.pos)
-        emit(L, tok.TK_COMMENT_LINE, b, L.s.substr(start, stop - start))
+        emit(L, tok.TK_COMMENT_LINE, b, str.SubstrIn(L.s, start, stop - start))
     end
     ret true
 end

--- a/std/str/basic.salam
+++ b/std/str/basic.salam
@@ -49,6 +49,24 @@ pub inline pure func Equals(a: str, b: str): bool: ret strcmp(a, b) == 0 end
 @ar "مقطع"
 pub inline func Substr(s: str, start: int, n: int): str: ret s.substr(start, n) end
 
+@en "SubstrIn"
+@fa "زیررشته درون"
+@ar "مقطع داخل"
+// Substr for a caller that already knows the slice is inside the string:
+// 0 <= start and start + n <= Len(s). Substr cannot know that, so it walks
+// the whole string with strlen just to clamp its two arguments - which a
+// scanner slicing every token out of one buffer pays once per token over
+// the entire buffer, making a single pass over a file quadratic in the
+// file's size. With the bounds supplied, copying n bytes is the only work
+// left. Same ownership as Substr: heap the caller frees.
+pub func SubstrIn(s: str, start: int, n: int): str:
+    mut ln := n
+    if ln < 0: ln = 0 end
+    r := mem.AllocateZeroed((ln + 1) as u64)
+    mem.Copy(r, ((_bp(s) as void*) as i64 + (start as i64)) as void*, ln as u64)
+    ret r as str
+end
+
 @en "Find"
 @fa "یافتن"
 @ar "بحث"


### PR DESCRIPTION
The online playground (https://salamlang.github.io/Salam/) freezes for about six seconds on every Run. Measured in headless Chrome against the live site:

| | before |
|---|---|
| Run button becomes usable | 6.8 s |
| longest task blocking the main thread on load | 6.5 s |
| every click of Run | ~5.9 s, in one long task |

A long task means the main thread is fully blocked - no scrolling, typing or clicks. Timing each wasm entry point separately showed it is not the page and not the download:

```
emit tokens      2 ms
emit ast         0 ms
emit symbols  5281 ms
run hello     5375 ms
```

## Cause

It reproduces natively, so `salam exec` on a three-line hello world under callgrind:

```
4,804,254,182 instructions total
3,900,340,763 (81.19%)  __strlen_avx2
```

`lex_slice` cut every token out of the source with `substr`, and `salam_str_substr` opens with `slen := s.len()` to clamp `start`/`n`. Copying a three-character token therefore walked the entire file, once per token, across every stdlib file sema loads - lexing was quadratic in file size.

## Fix

`str.SubstrIn`, a substr for callers that already know the slice is inside the string, used at the four lexer sites where `start` and `L.pos` are cursor positions and the bounds hold by construction.

## Result

Same hello world:

- 4.80G -> 613M instructions (7.8x less work)
- `strlen` 81.19% -> 2.30%
- 850 ms -> 96 ms (8.7x)

The profile is flat afterwards - memcpy 13%, strcmp 8.8%, no remaining hotspot.

## Tests

`general exec errors fmt stdlib`: 867 passed, 0 failed. `layout js repl editor-selected examples` was still running at 316/656 with 0 failures when this was opened.

## Not covered here

Two follow-ups this does not address:

- `fn_run_app` is still a synchronous wasm call on the main thread, so a run still blocks the tab, now for roughly 650 ms rather than 5.9 s. Moving `run_app`/`build_layout`/`emit` into a Web Worker is what removes freezing as a category; `syntax_ok` measures 0 ms and can stay where it is.
- 88% of what remains is `load_imports` re-lexing the whole stdlib on every call, with no cache between calls.
