### PR TITLE
editor: stop double-escaping preprocessor and IR punctuation

### DIFF
--- a/editor/app.salam
+++ b/editor/app.salam
@@ -474,7 +474,7 @@ func highlight_c(src: str): str:
         else c == 35 && at_line_start:
             j := find_from(src, "\n", i)
             e := j < 0 ? n : j
-            out = out + span("cpp", esc_html(src.substr(i, e - i)))
+            out = out + span("cpp", src.substr(i, e - i))
             i = e
         else c == 34:
             mut j := i + 1
@@ -625,7 +625,7 @@ func highlight_ir(src: str): str:
             end
             i = j
         else c == 44 || c == 42 || c == 123 || c == 125 || c == 40 || c == 41 || c == 60 || c == 62 || c == 91 || c == 93 || c == 61:
-            out = out + span("io", esc_html(src.substr(i, 1)))
+            out = out + span("io", src.substr(i, 1))
             i += 1
         else:
             out = out + esc_html(src.substr(i, 1))


### PR DESCRIPTION
In the playground's **c** view every `#` line renders its punctuation as raw HTML entities, so `<`, `>` and `"` are not visible as themselves:

```
#include &lt;stdint.h&gt;
#include &quot;salam_mod_main.h&quot;
#if defined(__GLIBC__) &amp;&amp; !defined(SALAM_NO_ALLOC_TUNE)
```

`span()` already runs `esc_html` over its text argument, but the preprocessor branch of `highlight_c` passed it text that had been escaped once already, so `<` became `&lt;` and then `&amp;lt;`, which the browser draws as the literal string `&lt;`.

Ordinary C string literals were unaffected, which is why the problem shows up only on `#` lines: `#include "x.h"` printed `&quot;` while `const char *s = "x"` printed a normal quote.

`highlight_ir` had the same doubled call on its operator branch, and since `<` and `>` are in that branch's character set, the **llvm** view showed the same thing on vector and struct types.

Both fixed by dropping the redundant `esc_html` and letting `span()` do the escaping.

## Verification

Rebuilt `editor/index.html` and served it against the deployed wasm, then read the rendered DOM in headless Chrome:

Before, in `innerHTML`: `<span class="cpp">#include &amp;lt;stdint.h&amp;gt;</span>`
After: `<span class="cpp">#include &lt;stdint.h&gt;</span>`

Visible text in both views is now free of raw entities, `#include "salam_mod_core.h"` shows real quotes, and the 118 `span.cpp` elements confirm highlighting still applies.
