### PR TITLE
macos: make llvm@22 the linked LLVM, and fail if it is not 22

### DIFF
--- a/.github/workflows/compiler-release.yml
+++ b/.github/workflows/compiler-release.yml
@@ -652,7 +652,41 @@ jobs:
 
           brew untap aws/tap || true
           brew install llvm@22 ccache
-          "$(brew --prefix llvm@22)/bin/llvm-config" --version
+
+          # The runner image preinstalls llvm@20, and it owns the unversioned
+          # symlinks, so brew leaves llvm@22 keg-only and every bare clang,
+          # llvm-ar or llvm-config on PATH is still 20. The steps below pass
+          # llvm-config by absolute path, but std/llvm/native/build.sh ends
+          # its AR search with a bare `command -v llvm-ar`, and that fallback
+          # taking 20 while the headers and archives are 22 surfaces as a
+          # link error nowhere near the cause. Make 22 the LLVM on PATH so
+          # there is only one version to find.
+          brew link --overwrite --force llvm@22 \
+            || echo "::warning::brew could not link llvm@22; the absolute prefix below still governs the build"
+
+          LLVM_PREFIX="$(brew --prefix llvm@22)"
+          echo "$LLVM_PREFIX/bin" >> "$GITHUB_PATH"
+
+          LLVM_VER="$("$LLVM_PREFIX/bin/llvm-config" --version)"
+          echo "llvm-config: $LLVM_VER  ($LLVM_PREFIX)"
+          case "$LLVM_VER" in
+          22.*) ;;
+          *)
+              echo "::error::expected LLVM 22 from the llvm@22 keg, got $LLVM_VER"
+              exit 1
+              ;;
+          esac
+
+          # Whatever a bare name now resolves to is what an unqualified tool
+          # lookup gets, so say it out loud rather than leaving it implied.
+          if command -v llvm-config >/dev/null 2>&1; then
+              BARE_VER="$(llvm-config --version 2>/dev/null || echo unknown)"
+              echo "bare llvm-config on PATH: $BARE_VER"
+              case "$BARE_VER" in
+              22.*) ;;
+              *) echo "::warning::a bare llvm-config on PATH is $BARE_VER, not 22" ;;
+              esac
+          fi
 
           PKGS_AFTER=$(fingerprint "$HOME/Library/Caches/Homebrew/downloads")
           if [ -n "$PKGS_AFTER" ] && [ "$PKGS_BEFORE" = "$PKGS_AFTER" ]; then

--- a/std/llvm/native/build.sh
+++ b/std/llvm/native/build.sh
@@ -124,6 +124,11 @@ to_ar_path() {
 trap 'rm -rf "$WORK"' EXIT INT TERM
 
 echo "llvm-config : $LLVM_CONFIG ($($LLVM_CONFIG --version))"
+# AR is picked by a fallback chain that ends at whatever `llvm-ar` PATH
+# happens to offer, which on a machine carrying two LLVM kegs need not be
+# the one llvm-config points at. Printing it costs nothing and turns a
+# version mismatch into a visible line instead of a later link error.
+echo "ar          : ${AR:-none}"
 echo "in-process LLD : $([ "$WITH_LLD" = 1 ] && echo yes || echo 'no (stubbed)')"
 
 # -DSALAM_HAVE_LLVM is what makes orc_call.c define the five


### PR DESCRIPTION
The macOS job logs:

```
llvm@22 was installed but not linked because llvm@20 is already installed.
To link this version, run: brew link llvm@22
```

`llvm@20` is not installed by this repo. It is preinstalled on GitHub's macOS runner image, and it owns the unversioned symlinks, so Homebrew leaves `llvm@22` keg-only. Every bare `clang`, `llvm-ar` or `llvm-config` on PATH is therefore LLVM 20.

## Why it has not broken yet, and why that is not reassuring

Both places that matter address LLVM 22 by absolute path:

```bash
LLVM_PREFIX="$(brew --prefix llvm@22)"
sh std/llvm/native/build.sh --llvm-config "$LLVM_PREFIX/bin/llvm-config" ...
```

But `std/llvm/native/build.sh:65` picks its archiver from a fallback chain:

```sh
: "${AR:=$(command -v "$BINDIR/llvm-ar" ... || command -v llvm-ar ... || command -v ar)}"
```

`$BINDIR` comes from the llvm-config that was passed in, so today the first branch wins and the correct `llvm-ar` is used. The moment that branch misses, the next one takes LLVM 20's `llvm-ar` while the headers and archives are 22, and that surfaces as a link error nowhere near its cause.

## Change

- `brew link --overwrite --force llvm@22`, so there is one LLVM on PATH rather than two with the older one winning. Non-fatal if it fails, since the absolute prefix still governs the build.
- Prepend `$LLVM_PREFIX/bin` to PATH for later steps.
- Assert `llvm-config --version` starts with `22.` and fail the job otherwise, so a runner image change is loud instead of silent.
- Report what a bare `llvm-config` resolves to after linking.
- `build.sh` now prints the `ar` it settled on, which is the one value in that fallback chain nothing was showing.

## Checks

Workflow YAML parses, the step shellchecks clean, and the version gate accepts `22.1.0` and `22.0.0git` while rejecting `20.1.8` and `21.1.0`.
