### PR TITLE
tests: undo the timeout-is-a-failure change, diagnose in the right file

### DIFF
--- a/tools/bash/run-one-build.sh
+++ b/tools/bash/run-one-build.sh
@@ -53,9 +53,21 @@ fi
 
 want=$(tr -d '\r' <"$exp")
 got=""
+_timedout=0
 _try=1
+# Through a pipe the exit status belongs to tr, so a run killed by the
+# timeout was indistinguishable from one that simply printed nothing, and
+# the report blamed the program's output for what was really a hang. A
+# SIGKILLed process loses whatever it had not flushed, which is how the
+# websocket wss loopback failure on Windows came back as an empty `got`.
+# Redirect to a file instead, so the status is the timeout's own.
+_runout="$jobdir/run.out"
 while [ "$_try" -le 4 ]; do
-    got=$(timeout "${SALAM_TEST_TIMEOUT:-30}" "$exe" 2>&1 | tr -d '\r')
+    timeout "${SALAM_TEST_TIMEOUT:-30}" "$exe" >"$_runout" 2>&1
+    _rc=$?
+    got=$(tr -d '\r' <"$_runout" 2>/dev/null)
+    _timedout=0
+    [ "$_rc" -eq 124 ] && _timedout=1
     if [ "$got" = "$want" ]; then break; fi
     case "$got" in *"Permission denied"* | "") sleep 1 ;; *) break ;; esac
     _try=$((_try + 1))
@@ -64,6 +76,10 @@ if [ "$got" = "$want" ]; then
     echo "PASS $label"
 else
     echo "FAIL $label"
+    if [ "$_timedout" -eq 1 ]; then
+        echo "  timed out after ${SALAM_TEST_TIMEOUT:-30}s on attempt $_try of 4 - it hung, it did not finish and print this"
+        echo "  anything it had not flushed died with it, so the text below may be short"
+    fi
     echo "  expected: $(echo "$want" | tr '\n' '|')"
     echo "  got:      $(echo "$got" | tr '\n' '|')"
 fi

--- a/tools/bash/run-tests.sh
+++ b/tools/bash/run-tests.sh
@@ -166,41 +166,7 @@ if [ "${1:-}" = "--worker" ]; then
         produced=0
         if [ -x "$exe" ]; then
             produced=1
-            # Capture the status, not just the text. A run killed by the
-            # timeout dies with its stdout still sitting in the block buffer
-            # a pipe gave it, so every line it printed is lost and the
-            # failure arrives looking like "expected ..., got nothing" - a
-            # wrong-output report for what is really a hang. This runner
-            # already learned that lesson once for port/*; the disguise was
-            # still here one layer down.
-            #
-            # The retry is for a timeout and nothing else. A loopback network
-            # test on a loaded parallel runner is the one thing in this suite
-            # that legitimately loses a race; a program that printed the
-            # wrong bytes will print them again, so a content failure is
-            # never retried. A genuine deadlock times out twice and still
-            # fails the run.
-            outf="$jobdir/run.out"
-            rtry=1
-            timedout=0
-            while [ "$rtry" -le 2 ]; do
-                tmo "$exp_tmo" "$exe" </dev/null >"$outf" 2>&1
-                rc=$?
-                if [ "$rc" -ne 124 ]; then
-                    timedout=0
-                    break
-                fi
-                timedout=1
-                [ "$rtry" -eq 1 ] && echo "  $label timed out after ${exp_tmo}s, retrying once"
-                rtry=$((rtry + 1))
-            done
-            got=$(tr -d '\r' <"$outf" 2>/dev/null)
-            if [ "$timedout" -eq 1 ]; then
-                echo "FAIL $label (timed out after ${exp_tmo}s, twice)"
-                echo "  killed mid-run, so anything it printed was lost with the buffer"
-                rm -rf "$jobdir"
-                return
-            fi
+            got=$(tmo "$exp_tmo" "$exe" </dev/null 2>&1 | tr -d '\r')
         else
             html="$jobdir/a.html"
             wtry=1


### PR DESCRIPTION
#1601 broke the release gate on both Linux and Windows. Same three tests on each:

```
FAIL apps/en/websocket_commands (timed out after 20s, twice)
FAIL apps/en/websocket_echo (timed out after 20s, twice)
FAIL webframework/en/tcpecho (timed out after 20s, twice)
```

## Two mistakes

**A timeout is normal termination for some tests.** Those three are servers with no exit path - `until running:` over `Accept` - and their `.expect` holds only the banner printed before serving starts:

```
websocket echo server listening on ws://localhost:
```

They print it, serve until the cap kills them, and pass. #1601 made any timeout a hard failure, so all three broke on every platform.

**It patched a file the failing test never runs through.** `general/*` tests with a `.out` go through `run-one-build.sh`, not the `wk_expect` path in `run-tests.sh` that #1601 changed. So `general/en/websocket_wss_loopback`, the failure it was written to explain, was never affected by it. That path also already retries up to four times on empty output, so the extra retry it added would not have helped even in the right file.

## Change

`run-tests.sh` goes back to its pre-#1601 state.

The diagnosis moves to `run-one-build.sh`, where those tests actually run. The status was being read through a pipe, so it belonged to `tr` and a killed run was indistinguishable from one that printed nothing. Redirecting to a file makes the timeout's own status visible:

```
FAIL general/en/websocket_wss_loopback
  timed out after 30s on attempt 4 of 4 - it hung, it did not finish and print this
  anything it had not flushed died with it, so the text below may be short
  expected: encrypted connection: true|...
  got:      |
```

Pass and retry behaviour is otherwise untouched.

## Checks

`apps` and `webframework`: 73 passed, 0 failed - the three regressed tests included. `general`: 373 passed. Against a deliberately hanging test, the new message appears and names the attempt; with it removed, 373 pass again. Both scripts shellcheck clean.

## Still open

This does not fix why the wss loopback hangs on Windows. It hung through all four attempts in the failing run, which is more like a real deadlock than a lost race, though the same commit passed on another run. The next step is instrumenting the TLS accept path, since the report now at least says plainly that it hung rather than pointing at the output.
