### PR TITLE
tls: bound the handshake, so a silent peer cannot pin a thread

### DIFF
--- a/std/tls/conn.salam
+++ b/std/tls/conn.salam
@@ -199,7 +199,9 @@ pub func Dial(host: str, port: int, cfg: Config): Conn:
     c.h.srand = _newbuf(32)
     c.h.ecpriv = _newbuf(32)
     c.h.ecpub = _newbuf(65)
+    c.h.rec.read_deadline_ms = HANDSHAKE_READ_TIMEOUT_MS
     _do_handshake(c, conf)
+    c.h.rec.read_deadline_ms = 0
     ret c
 end
 
@@ -240,7 +242,9 @@ pub func WrapClient(fd: i64, cfg: Config): Conn:
     c.h.srand = _newbuf(32)
     c.h.ecpriv = _newbuf(32)
     c.h.ecpub = _newbuf(65)
+    c.h.rec.read_deadline_ms = HANDSHAKE_READ_TIMEOUT_MS
     _do_handshake(c, conf)
+    c.h.rec.read_deadline_ms = 0
     ret c
 end
 
@@ -291,7 +295,12 @@ pub func WrapServer(fd: i64, cfg: ServerConfig): Conn:
     c.h.srand = _newbuf(32)
     c.h.ecpriv = _newbuf(32)
     c.h.ecpub = _newbuf(65)
+    // A peer that connects and then goes quiet must not pin this thread
+    // for the life of the process, which is what an unbounded recv on an
+    // accepted socket does.
+    c.h.rec.read_deadline_ms = HANDSHAKE_READ_TIMEOUT_MS
     _do_server_handshake(c, cfg)
+    c.h.rec.read_deadline_ms = 0
     ret c
 end
 

--- a/std/tls/record.salam
+++ b/std/tls/record.salam
@@ -57,6 +57,14 @@ const ALERT_DECRYPT_ERROR := 51
 const ALERT_PROTOCOL_VERSION := 70
 const ALERT_INTERNAL_ERROR := 80
 
+// How long one handshake read may wait on the peer. Generous on purpose:
+// it is a backstop against a connection that stalls forever, not a
+// performance bound, and a loaded CI runner doing a full handshake in
+// software has been seen to need seconds. Only the handshake uses it; an
+// established connection keeps waiting indefinitely, which is what an idle
+// WebSocket needs.
+const HANDSHAKE_READ_TIMEOUT_MS := 15000
+
 // ---------------------------------------------------------------- transport
 
 struct RecordLayer:
@@ -68,6 +76,13 @@ struct RecordLayer:
     pub eof: bool = false
     pub failed: bool = false
     pub err: str = ""
+    // Milliseconds a single fill may wait for the peer, or 0 for "block as
+    // long as it takes". Only the handshake sets it: an established
+    // connection is allowed to sit idle indefinitely, because that is what
+    // a WebSocket between messages looks like, but a peer that opens a
+    // connection and then says nothing must not pin the accepting thread
+    // for the life of the process.
+    pub read_deadline_ms: int = 0
 end
 
 func _rec_new(fd: i64): RecordLayer:
@@ -92,6 +107,18 @@ end
 
 // Pull more bytes from the socket into the receive buffer.
 func _rec_fill(r &: RecordLayer): bool:
+    // WaitReadable, never SetTimeout: a timed recv() that expires halfway
+    // through a record consumes the bytes it did get and leaves this layer
+    // holding a fragment it can never finish. poll() touches no bytes, so
+    // it composes with a buffering transport the way a timed recv does not
+    // - the reasoning is spelled out on rawsock.WaitReadable itself.
+    if r.read_deadline_ms > 0:
+        if !rawsock.WaitReadable(rawsock.FromFd(r.fd), r.read_deadline_ms):
+            _rec_fail(r, "timed out waiting for the peer")
+            r.eof = true
+            ret false
+        end
+    end
     mut tmp := _newbuf(4096)
     defer _buf_free(tmp)
     _putzeros(tmp, 4096)


### PR DESCRIPTION
`general/en/websocket_wss_loopback` hangs on the Windows release gate, producing no output at all. It survived all four retries in `run-one-build.sh`, so it is closer to a deadlock than a lost race.

## The unbounded read

`_rec_fill` in `std/tls/record.salam` called `recv` with no deadline, and `_rec_need` loops on it until enough bytes arrive:

```salam
n := rawsock.RecvBytes(rawsock.FromFd(r.fd), tmp.p, 4096)
```

A peer that completes the TCP handshake and then says nothing blocks the accepting thread for the life of the process. Nothing higher up can recover it, because the thread never returns to check anything.

This is not a new suspicion. `std/net/websocket/websocket.salam`'s own header records it:

> wss:// SERVER support (AcceptWSS) was carried over from the migration marked unverified, on the strength of a local check that found std/tls's WrapServer hanging mid-handshake with no test anywhere to compare against.

## Change

A `read_deadline_ms` on the record layer, gated through `rawsock.WaitReadable` before each fill.

`WaitReadable`, not `SetTimeout`, and the reason is written on `WaitReadable` itself: a timed `recv` that expires halfway through a record consumes the bytes it did get and leaves the record layer holding a fragment it can never finish. `poll` touches no bytes, so it composes with a buffering transport.

Only the three handshake entry points set it (`Dial`, the STARTTLS-style client wrap, and `WrapServer`), and each clears it afterwards. An established connection still waits indefinitely, because an idle WebSocket between messages is not an error.

## Checks

A silent peer is now refused rather than hanging. With the constant temporarily lowered to 2s so the probe is quick:

```
connected a silent peer: true
server gave up: refused
within 10s: true
```

With the shipped 15s value: `general apps webframework ssl db` gives **486 passed, 0 failed**, `websocket_wss_loopback` included.

## What this does and does not settle

It removes the failure mode where the process hangs until the harness kills it with nothing to show. If Windows is stalling mid-handshake, the server now gives up and reports it, and combined with the timeout reporting from #1602 the next failure should say plainly what happened rather than showing an empty `got`.

It does not explain *why* the peer stalls on Windows in the first place. If it recurs with a handshake error rather than a hang, that error is the next thread to pull.
