### PR TITLE
docs: mark v0.3.6 as the stable release

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -28,7 +28,9 @@ site:
       children:
         - title: Latest (Dev)
           url: https://salamlang.readthedocs.io/latest/
-        - title: v0.3.5 (Stable)
+        - title: v0.3.6 (Stable)
+          url: https://salamlang.readthedocs.io/v0.3.6/
+        - title: v0.3.5
           url: https://salamlang.readthedocs.io/v0.3.5/
         - title: v0.3.4
           url: https://salamlang.readthedocs.io/v0.3.4/


### PR DESCRIPTION
v0.3.6 is released, so the Versions nav now points at it as stable and v0.3.5 keeps its entry without the label.

```
Latest (Dev)
v0.3.6 (Stable)   <- new
v0.3.5            <- was (Stable)
v0.3.4
v0.3.3
v0.3.0
```

Exactly one entry carries the Stable label, and the file still parses.