### PR TITLE
ci: block a commit that bumps one version site and not the rest

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -40,6 +40,16 @@ hooks = [
     pass_filenames = false
   },
   {
+    id = "version-sync",
+    name = "every hardcoded version matches VERSION",
+    description = "block a commit that moves one version site and leaves the others behind: VERSION, pyproject, the vscode extension manifest and the bun.lock entry that shadows it, the MCP plugin, the book transcript, the profiling sample and the readthedocs menu in myst.yml",
+    priority = 40,
+    entry = "sh tools/bash/check-version.sh",
+    files = '^(VERSION$|myst\.yml$|pyproject\.toml$|bun\.lock$|extensions/vscode/package\.json$|tools/mcp/claude-plugin/\.claude-plugin/plugin\.json$|books/en/intro-programming/chapters/01-getting-started\.tex$|docs/PROFILING\.md$|tools/salam/update-version\.salam$)',
+    language = "system",
+    pass_filenames = false
+  },
+  {
     id = "stdlib-index",
     name = "refresh the stdlib index",
     description = "regenerate docs/ai/stdlib-index.json so a stale copy blocks the commit instead of the pull request",

--- a/tools/bash/check-version.sh
+++ b/tools/bash/check-version.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Fails the commit when any hardcoded version disagrees with VERSION.
+#
+# The site list lives in tools/salam/update-version.salam, so the hook, the
+# updater and the CI job all read one table and none of them can drift from
+# the others. This wrapper only finds a compiler to run it with.
+set -eu
+
+root=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
+cd "$root"
+
+# A released salam on PATH, the repo's own build, or $SALAM. Without one the
+# hook steps aside rather than failing the commit: a contributor who has not
+# built the compiler yet still gets every other hook, and the CI job
+# (lint-version-sync.yml) installs a compiler and runs the same check, so
+# nothing reaches main unchecked.
+salam=${SALAM:-}
+if [ -z "$salam" ] && command -v salam >/dev/null 2>&1; then
+    salam=$(command -v salam)
+fi
+if [ -z "$salam" ] && [ -x "$root/salam" ]; then
+    salam="$root/salam"
+fi
+if [ -z "$salam" ]; then
+    printf 'no salam compiler found; skipping the version check.\n' >&2
+    printf 'Build one (tools/bash/build-selfhost.sh) or set $SALAM to enable it.\n' >&2
+    exit 0
+fi
+
+exec "$salam" run tools/salam/update-version.salam check

--- a/tools/salam/update-version.salam
+++ b/tools/salam/update-version.salam
@@ -81,6 +81,13 @@ func sites(): Vector<Site>:
     // examples in the same chapter.
     v.push(Site { path = "books/en/intro-programming/chapters/01-getting-started.tex", prefix = "$ salam version\nsalam ", suffix = "\n" })
     v.push(Site { path = "docs/PROFILING.md", prefix = "\"salam_version\": \"", suffix = "\"" })
+    // The readthedocs menu in myst.yml names the current release twice: once
+    // as the entry labelled "(Stable)" and once in that entry's URL. Both are
+    // anchored on the lowercase "v", which the menu's own "- title: Versions"
+    // heading cannot collide with, and on "readthedocs.io/v", which the
+    // "latest" URL above it does not contain.
+    v.push(Site { path = "myst.yml", prefix = "- title: v", suffix = " (Stable)" })
+    v.push(Site { path = "myst.yml", prefix = "readthedocs.io/v", suffix = "/" })
     // bun records each workspace member's own version, so the lockfile goes
     // stale the moment extensions/vscode/package.json moves without it. The
     // anchor carries the package name above it because a bare "version": "
@@ -177,7 +184,53 @@ func check_all(want: str): int:
     ret bad
 end
 
+// myst.yml's Versions menu is a list, not a single field. Bumping it means
+// the new release takes the "(Stable)" label and the release it replaces
+// stays in the menu without one - which is what a reader following an old
+// link needs. The generic substitution below would overwrite the old entry
+// instead, silently dropping that release from the documentation menu, so
+// the promotion happens here first and the table then finds it already
+// correct.
+func myst_promote(want: str): bool:
+    path := "myst.yml"
+    if os.Exists(path) == false:
+        ret false
+    end
+    body := os.ReadFile(path)
+    old := read_at(body, "- title: v", " (Stable)")
+    if old.len() == 0 || old == want:
+        ret false
+    end
+    mut out := write_at(body, "- title: v", " (Stable)", want)
+    out = write_at(out, "readthedocs.io/v", "/", want)
+
+    marker := "- title: v" + want + " (Stable)"
+    at := out.find(marker)
+    if at < 0:
+        ret false
+    end
+    from := at + marker.len()
+    rest := out.substr(from, out.len() - from)
+    nl1 := rest.find("\n")
+    if nl1 < 0:
+        ret false
+    end
+    tail_from := nl1 + 1
+    after := rest.substr(tail_from, rest.len() - tail_from)
+    nl2 := after.find("\n")
+    if nl2 < 0:
+        ret false
+    end
+    cut := from + tail_from + nl2 + 1
+    ins := "        - title: v" + old + "\n" + "          url: https://salamlang.readthedocs.io/v" + old + "/\n"
+    out = out.substr(0, cut) + ins + out.substr(cut, out.len() - cut)
+    _n := os.WriteFile(path, out)
+    println "  promoted      ", path, old, "->", want, "- and kept", old, "in the menu"
+    ret true
+end
+
 func sync_all(want: str): int:
+    _promoted := myst_promote(want)
     mut changed := 0
     all := sites()
     defer all.free()


### PR DESCRIPTION
A version check already existed and CI already ran it, but two things were missing: the readthedocs menu was not among the sites it knew about, and nothing ran it before a push.

## The gap it closes

`myst.yml` names the current release twice, in the menu entry and in that entry's URL, and neither was checked. It sat on `v0.3.5 (Stable)` through two v0.3.6 releases and only moved when someone noticed by hand.

Both are tracked now:

```
ok  pyproject.toml
ok  extensions/vscode/package.json
ok  tools/mcp/claude-plugin/.claude-plugin/plugin.json
ok  books/en/intro-programming/chapters/01-getting-started.tex
ok  docs/PROFILING.md
ok  myst.yml          <- the (Stable) entry
ok  myst.yml          <- its readthedocs URL
ok  bun.lock
```

## The menu is a list, so bumping it inserts

Every other site holds one version and a substitution is right. The menu holds a history, and overwriting the stable entry would drop that release from the documentation while old links still point at it. `myst_promote` gives the label to the new release and keeps the previous one listed without it:

```
Latest (Dev)
v0.3.7 (Stable)   <- promoted
v0.3.6            <- kept, demoted
v0.3.5
```

Verified idempotent: a second run leaves seven entries and one Stable label, not eight.

## The hook

`version-sync` in `prek.toml`, running `tools/bash/check-version.sh`. The site list stays in `update-version.salam`, so the hook, the updater and `lint-version-sync.yml` all read one table and cannot drift apart.

It steps aside when no compiler is on PATH, the way the stdlib-index hook does. A contributor who has not built one still gets every other hook, and CI installs a compiler and runs the same check, so nothing reaches main unchecked.

## Checks

Four cases, all through `prek run version-sync`:

- consistent tree: **Passed**
- only the vscode manifest bumped: fails, names the file, prints the fix command
- VERSION bumped with the menu forgotten: fails on both myst.yml sites
- no compiler on PATH: skips, exit 0

The pre-existing `prek.toml` uses multi-line inline tables, which strict TOML parsers reject and prek accepts; that is unchanged, and prek parses the file with the new hook in it.
