### PR TITLE
docs: record which hardcoded versions are deliberately not tracked

### DIFF
--- a/tools/salam/update-version.salam
+++ b/tools/salam/update-version.salam
@@ -56,6 +56,22 @@
 //       change makes older seeds unusable, and its own comment says the c/
 //       fallback no-ops "once SEED_MIN is published". Bumping it every
 //       release would keep that temporary fallback alive forever.
+//   tools/bash/build-selfhost.sh
+//       "a seed older than 0.3.6 mangles those names" is the same kind of
+//       floor: it records which release fixed the doubled underscores, and
+//       moving it with each bump would claim every future seed is broken.
+//   install.sh, docs/GETTING_STARTED.md
+//       "--version 0.3.6" demonstrates the flag's syntax. The number is an
+//       example of the shape an argument takes, not a statement about which
+//       release is current, and a reader copying it gets a version that
+//       exists either way.
+//
+// myst.yml's TOP-LEVEL `version: 1` is NOT a release version - it is the
+// config schema version MyST itself defines, and mystmd has no project-level
+// version field at all (checked against mystmd 1.10.1). The two entries in
+// the table below anchor on the Versions menu instead. Anchoring anything on
+// that `version:` would pin the schema number to the release number and
+// break the site config on the next bump.
 package main
 
 import os


### PR DESCRIPTION
Follow-up to #1606, checking the version work against what mystmd actually defines and sweeping for anything the table still misses.

## mystmd

Checked against the real CLI (mystmd 1.10.1) rather than assumed:

- **MyST has no project-level `version` field.** The frontmatter reference lists title, description, keywords, authors, license, github and the rest; there is nothing to hold a release number, so the Versions menu in `site.nav` is the only place `myst.yml` names one, and #1606 already tracks both halves of it.
- **The top-level `version: 1` is MyST's config schema version, not ours.** It looks exactly like a site the table should pick up. Anchoring there would pin a schema number to the release number and break the config on the next bump, so it is now written down as a trap rather than left to be rediscovered.
- The config is valid: `myst build` parses it and builds all 8 pages with no config diagnostics.

## Sweep

Every file carrying `0.3.5` or `0.3.6`. Eight are tracked; three are not, on purpose, and now say why:

| file | what it is |
|---|---|
| `tools/bash/build-selfhost.sh` | "a seed older than 0.3.6 mangles those names" - a capability floor like `SEED_MIN`. Bumping it would claim every future seed is broken. |
| `install.sh` | `--version 0.3.6` in a usage comment, showing the flag's shape |
| `docs/GETTING_STARTED.md` | the same flag example |

Comments only; `check` still reports all eight sites agreeing on 0.3.6.

## Separate finding, not touched here

`LICENSE` is GPL v3 while `extensions/vscode/package.json` declares `"license": "MIT"`. Those cannot both be right, and which one is authoritative is not a call to make from a version sweep. Left alone deliberately, and it is also why no `license` field was added to `myst.yml`.
