### PR TITLE
stamp the full commit hash, not an abbreviation

### DIFF
--- a/compiler/tools/bash/bootstrap.sh
+++ b/compiler/tools/bash/bootstrap.sh
@@ -267,7 +267,11 @@ has_inprocess_llvm() {
 # place the release number lives; the git metadata describes the tree being
 # compiled, not the compiler doing the compiling.
 STAMP_VERSION="$(cat "$ROOT/VERSION" 2>/dev/null || echo 0.0.0-dev)"
-STAMP_COMMIT="$(git -C "$ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+# The full 40-character hash, not --short: an abbreviation is only
+# unique until the repository grows into a collision, and anything
+# reading SALAM_GIT_COMMIT to identify a build - a bug report, a
+# reproducibility check - wants the name that always resolves.
+STAMP_COMMIT="$(git -C "$ROOT" rev-parse HEAD 2>/dev/null || echo unknown)"
 # Strict ISO 8601 (%cI, not %ci): the flag list below is word-split on the
 # way to the build command, so a commit date with spaces in it would arrive
 # as four separate arguments. The C Makefile stamps the same format.

--- a/tools/bash/build-selfhost.sh
+++ b/tools/bash/build-selfhost.sh
@@ -118,7 +118,11 @@ set --
 # number instead of this checkout's. Same stamping bootstrap.sh does. %cI, not
 # %ci, so the date carries no spaces.
 STAMP_VERSION="$(cat "$ROOT/VERSION" 2>/dev/null || echo 0.0.0-dev)"
-STAMP_COMMIT="$(git -C "$ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+# The full 40-character hash, not --short: an abbreviation is only
+# unique until the repository grows into a collision, and anything
+# reading SALAM_GIT_COMMIT to identify a build - a bug report, a
+# reproducibility check - wants the name that always resolves.
+STAMP_COMMIT="$(git -C "$ROOT" rev-parse HEAD 2>/dev/null || echo unknown)"
 STAMP_DATE="$(git -C "$ROOT" show -s --format=%cI HEAD 2>/dev/null || echo unknown)"
 STAMP_DIRTY=
 if [ -n "$(git -C "$ROOT" status --porcelain 2>/dev/null)" ]; then


### PR DESCRIPTION
`SALAM_GIT_COMMIT` and the `commit:` line in `salam version` carried eight characters, because both stampers used `rev-parse --short`.

An abbreviation is only unique until the repository grows into a collision, and everything that reads this value wants a name that always resolves: a bug report naming the build, a reproducibility check, or pasting it into a GitHub URL.

## Change

`rev-parse --short HEAD` becomes `rev-parse HEAD` in the two places that stamp it, `tools/bash/build-selfhost.sh` and `compiler/tools/bash/bootstrap.sh`. `cli_api.salam` already printed whatever was stamped, so nothing else needed touching.

## After

```
$ salam version
salam 0.3.7
commit:  57a993fb0ba299db1f0b78482fffc320c4ac0f29-dirty
date:    2026-09-07T13:29:13+03:30
built:   Sep 07 2026 10:01:12
```

```salam
println SALAM_GIT_COMMIT        // 57a993fb0ba299db1f0b78482fffc320c4ac0f29
println SALAM_GIT_COMMIT.len()  // 40
```

Built through `build-selfhost.sh` itself rather than a direct compile, so the stamping path is the one that actually ran, and the value matches `git rev-parse HEAD` exactly. The `-dirty` suffix still appends correctly.

Checked that nothing consumes the short form: `cli_test.salam` only asserts the output contains `commit:`, and `core_test.salam` only that the constant is non-empty.
