### PR TITLE
ci: sign the release tag, so the tag can verify at all

### DIFF
--- a/.github/workflows/compiler-release.yml
+++ b/.github/workflows/compiler-release.yml
@@ -2517,6 +2517,62 @@ jobs:
           fi
           gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/$TAG" >/dev/null 2>&1 || true
           git tag -d "$TAG" 2>/dev/null || true
+      - name: Create a signed, annotated tag
+        id: signtag
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          GPG_SIGNING_KEY_ID: ${{ secrets.GPG_SIGNING_KEY_ID }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eu
+          # Without the key this step does nothing and the release below
+          # creates its own lightweight tag exactly as before, so a fork or a
+          # repository that has not set the secret still cuts releases.
+          if [ -z "${GPG_PRIVATE_KEY:-}" ]; then
+            echo "signed=false" >> "$GITHUB_OUTPUT"
+            echo "no GPG_PRIVATE_KEY secret; the release will carry an unsigned lightweight tag"
+            exit 0
+          fi
+
+          # A lightweight tag is a ref pointing straight at a commit - there
+          # is no tag object to hold a signature, which is why every tag this
+          # workflow has produced so far shows no verification on GitHub.
+          # Only an annotated tag can be signed.
+          printf '%s\n' "$GPG_PRIVATE_KEY" | gpg --batch --quiet --import
+          KEY_ID="${GPG_SIGNING_KEY_ID:-}"
+          if [ -z "$KEY_ID" ]; then
+            KEY_ID=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec:/ {print $5; exit}')
+          fi
+          [ -n "$KEY_ID" ] || { echo "::error::imported a GPG key but could not read its id"; exit 1; }
+          echo "signing with $KEY_ID"
+
+          # loopback pinentry: there is no tty on a runner to prompt on.
+          mkdir -p "$HOME/.gnupg"
+          chmod 700 "$HOME/.gnupg"
+          echo "allow-loopback-pinentry" >> "$HOME/.gnupg/gpg-agent.conf"
+          gpgconf --reload gpg-agent || true
+
+          git config user.name "${GIT_TAGGER_NAME:-$GITHUB_ACTOR}"
+          git config user.email "${GIT_TAGGER_EMAIL:-$GITHUB_ACTOR@users.noreply.github.com}"
+          git config user.signingkey "$KEY_ID"
+          git config gpg.program gpg
+          if [ -n "${GPG_PASSPHRASE:-}" ]; then
+            git config gpg.program "$PWD/.gpg-batch"
+            printf '#!/bin/sh\nexec gpg --batch --pinentry-mode loopback --passphrase "$GPG_PASSPHRASE" "$@"\n' > .gpg-batch
+            chmod +x .gpg-batch
+          fi
+
+          git tag -s "$TAG" -m "$RELEASE_TITLE" "$GITHUB_SHA"
+          git tag -v "$TAG" || { echo "::error::the tag did not verify locally"; exit 1; }
+
+          # persist-credentials is false on the checkout, so the push needs
+          # the token spelled out rather than a stored helper.
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "refs/tags/$TAG"
+          rm -f .gpg-batch
+          echo "signed=true" >> "$GITHUB_OUTPUT"
+          echo "pushed a signed annotated tag $TAG"
+
       - name: Create GitHub Release with auto-generated notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -2621,8 +2677,14 @@ jobs:
           # --notes-file prepends to the generated notes rather than
           # replacing them, so the verification instructions land above the
           # usual changelog instead of dropping it.
+          # --target only when this workflow did not already push a tag:
+          # passing it alongside an existing ref makes gh create a second,
+          # lightweight one and the signature is lost.
+          TARGET_ARG="--target $GITHUB_SHA"
+          [ "${{ steps.signtag.outputs.signed }}" = "true" ] && TARGET_ARG=""
+          # shellcheck disable=SC2086 # deliberately empty or two words
           gh release create "$TAG" \
-            --target "$GITHUB_SHA" \
+            $TARGET_ARG \
             --title "$RELEASE_TITLE" \
             --notes-file release-notes-preamble.md \
             --generate-notes \


### PR DESCRIPTION
## What is already verified

Every commit on `main` is **already** `verified=true`:

```
6a4617f8  verified=true  reason=valid
a9f4ec04  verified=true  reason=valid
57a993fb  verified=true  reason=valid
```

Merging a PR goes through the GitHub API, and GitHub signs the commit it creates with its own key. No GPG setup is needed for that and none is added here.

## What is not, and why no key would have fixed it

The tags are **lightweight**:

```
v0.3.6 -> object.type = commit
v0.3.5 -> object.type = commit
```

A lightweight tag is a ref pointing straight at a commit. There is no tag object, so there is nothing to hold a signature. Registering a GPG key would not have changed this by itself: `gh release create --target <sha>` creates that kind of tag, and a signature has nowhere to live.

## Change

Before the release is created, and only when `GPG_PRIVATE_KEY` is set:

- import the key, resolve its id (or take `GPG_SIGNING_KEY_ID`)
- enable loopback pinentry, since a runner has no tty to prompt on
- `git tag -s` an annotated tag at the release commit
- `git tag -v` it, and fail the job if it does not verify
- push the tag with the token spelled out, because the checkout sets `persist-credentials: false`

`gh release create` then drops `--target` so it attaches to that tag rather than creating a second lightweight one over it.

With no secret the step exits early and the release is cut exactly as before, so forks and anyone without the secret are unaffected.

## Verified locally

Ran the whole sequence against a throwaway ed25519 key, since none of it can be tested from the workflow file alone:

- `git cat-file -t` on the result is `tag`, not `commit`, so it is genuinely annotated
- `git tag -v` reports `Good signature`
- exporting the key armored, importing into a clean keyring and signing again works, which is the path CI takes with the secret

The throwaway key and its export were deleted afterwards. The step shellchecks clean.

One practical note found while testing: `gpg-agent` fails to start when `GNUPGHOME` is a long path, because the agent socket exceeds the unix socket limit. Runner home directories are short, so this does not bite in CI, but it is worth knowing if anyone reproduces it in a deep scratch directory.
