### PR TITLE
ci: publish the tag and release as the account, not the bot

### DIFF
--- a/.github/workflows/compiler-release.yml
+++ b/.github/workflows/compiler-release.yml
@@ -2523,7 +2523,12 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           GPG_SIGNING_KEY_ID: ${{ secrets.GPG_SIGNING_KEY_ID }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_TAGGER_NAME: ${{ secrets.GIT_TAGGER_NAME }}
+          GIT_TAGGER_EMAIL: ${{ secrets.GIT_TAGGER_EMAIL }}
+          # RELEASE_TOKEN is a PAT belonging to the account that should own
+          # the tag and the release. Without it everything is attributed to
+          # github-actions[bot], which is what GITHUB_TOKEN authenticates as.
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -eu
           # Without the key this step does nothing and the release below
@@ -2553,8 +2558,18 @@ jobs:
           echo "allow-loopback-pinentry" >> "$HOME/.gnupg/gpg-agent.conf"
           gpgconf --reload gpg-agent || true
 
-          git config user.name "${GIT_TAGGER_NAME:-$GITHUB_ACTOR}"
-          git config user.email "${GIT_TAGGER_EMAIL:-$GITHUB_ACTOR@users.noreply.github.com}"
+          # The tagger email has to be the one on the signing key, and that
+          # same address has to be verified on the account, or GitHub shows
+          # a valid signature as "Unverified" and credits nobody. Reading it
+          # off the key removes the chance of the two drifting apart; the
+          # GITHUB_ACTOR noreply address this used before could never match
+          # a key UID and so could never verify.
+          KEY_UID=$(gpg --list-keys --with-colons "$KEY_ID" | awk -F: '/^uid:/ {print $10; exit}')
+          KEY_EMAIL=$(printf '%s' "$KEY_UID" | sed -n 's/.*<\(.*\)>.*/\1/p')
+          KEY_NAME=$(printf '%s' "$KEY_UID" | sed 's/ *<.*//')
+          git config user.name "${GIT_TAGGER_NAME:-${KEY_NAME:-$GITHUB_ACTOR}}"
+          git config user.email "${GIT_TAGGER_EMAIL:-${KEY_EMAIL:-$GITHUB_ACTOR@users.noreply.github.com}}"
+          echo "tagging as $(git config user.name) <$(git config user.email)>"
           git config user.signingkey "$KEY_ID"
           # Always through the wrapper, passphrase or not. A runner has no
           # tty, so gpg must never be in a position to want a prompt: even a
@@ -2585,7 +2600,9 @@ jobs:
 
       - name: Create GitHub Release with auto-generated notes
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Same token as the tag: with RELEASE_TOKEN set the release is
+          # published by that account instead of github-actions[bot].
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -eu
           shopt -s nullglob


### PR DESCRIPTION
Every release is authored by the Actions app:

```
v0.3.7-nightly-2026-09-07  author=github-actions[bot]
v0.3.6                     author=github-actions[bot]
v0.3.5                     author=github-actions[bot]
```

That is what `secrets.GITHUB_TOKEN` authenticates as, so nothing done with it can be attributed to a person.

## Two separate attributions

**Who publishes.** `GH_TOKEN` becomes `secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN`, on both the tag push and `gh release create`. With a PAT set, the tag and the release belong to that account; without one, behaviour is unchanged and forks keep working.

**Who tagged, and whether it verifies.** The tagger was `$GITHUB_ACTOR@users.noreply.github.com`. A GPG key UID is never a noreply address, so the tagger and the key could not match and GitHub would have shown a valid signature as "Unverified", crediting nobody. The identity is now read from the signing key's own UID, which is the pairing GitHub actually checks:

```
uid:   Seyyed Ali Mohammadiyeh <MaxBaseCode@gmail.com>
name:  Seyyed Ali Mohammadiyeh
email: MaxBaseCode@gmail.com
```

`GIT_TAGGER_NAME` / `GIT_TAGGER_EMAIL` still override it if a different tagger is ever wanted.

Parsing verified against a real key built with the same name and address. Step shellchecks clean.