### PR TITLE
ci: drop the commented-out version-reporting steps

### DIFF
--- a/.github/workflows/compiler-release.yml
+++ b/.github/workflows/compiler-release.yml
@@ -2437,42 +2437,6 @@ jobs:
             (cd ./release && sha256sum "salam-${VERSION}-stdlib.tar.gz" "salam-${VERSION}-stdlib.zip")
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
-      # - name: Post Linux release file to SERVER_VERSIONS_API
-      #   env:
-      #     SERVER_VERSIONS_API: ${{ secrets.SERVER_VERSIONS_API }}
-      #     SERVER_VERSIONS_KEY: ${{ secrets.SERVER_VERSIONS_KEY }}
-      #   run: |
-      #     curl -X POST "$SERVER_VERSIONS_API" \
-      #       -F "file=@./release/salam-linux" \
-      #       -F "version=${{ env.VERSION }}" \
-      #       -F "date=$(date +'%Y-%m-%d')" \
-      #       -F "time=$(date +'%H:%M:%S')" \
-      #       -F "key='$SERVER_VERSIONS_KEY'" \
-      #       -F "platform=linux"
-      # - name: Post macOS release file to SERVER_VERSIONS_API
-      #   env:
-      #     SERVER_VERSIONS_API: ${{ secrets.SERVER_VERSIONS_API }}
-      #     SERVER_VERSIONS_KEY: ${{ secrets.SERVER_VERSIONS_KEY }}
-      #   run: |
-      #     curl -X POST "$SERVER_VERSIONS_API" \
-      #       -F "file=@./release/salam-mac" \
-      #       -F "version=${{ env.VERSION }}" \
-      #       -F "date=$(date +'%Y-%m-%d')" \
-      #       -F "time=$(date +'%H:%M:%S')" \
-      #       -F "key='$SERVER_VERSIONS_KEY'" \
-      #       -F "platform=macos"
-      # - name: Post Windows release file to SERVER_VERSIONS_API
-      #   env:
-      #     SERVER_VERSIONS_API: ${{ secrets.SERVER_VERSIONS_API }}
-      #     SERVER_VERSIONS_KEY: ${{ secrets.SERVER_VERSIONS_KEY }}
-      #   run: |
-      #     curl -X POST "$SERVER_VERSIONS_API" \
-      #       -F "file=@./release/salam-windows.exe" \
-      #       -F "version=${{ env.VERSION }}" \
-      #       -F "date=$(date +'%Y-%m-%d')" \
-      #       -F "time=$(date +'%H:%M:%S')" \
-      #       -F "key='$SERVER_VERSIONS_KEY'" \
-      #       -F "platform=windows"
       - name: Check every zip has a matching tar.gz
         run: |
           set -eu


### PR DESCRIPTION
Three steps in `create-release`, commented out, posting to `SERVER_VERSIONS_API`. They point at `./release/salam-linux`, `salam-mac` and `salam-windows.exe` - bare binaries the release no longer publishes, whose entries in the asset list are commented out as well.

The only live effect they had was keeping `SERVER_VERSIONS_API` and `SERVER_VERSIONS_KEY` looking referenced, so a sweep for unused secrets skipped both.

Removing them makes those two secrets visibly unused, which is what they are.

Nothing else changes: 30 steps before and after, YAML parses.