### PR TITLE
console: cast the write count to the width the declaration takes

### DIFF
--- a/std/console/console.salam
+++ b/std/console/console.salam
@@ -65,7 +65,14 @@ end
 if SALAM_OS_WINDOWS:
     func _err_raw(s: str): _write(2, s as void*, s.len() as u32) end
 else:
-    func _err_raw(s: str): write(2, s as void*, s.len() as u64) end
+    // The cast has to track the declaration above: on a 32-bit target the
+    // count parameter is u32, and a u64 argument is a type error rather
+    // than a silent narrowing.
+    if SALAM_ARCH_X64 || SALAM_ARCH_ARM64:
+        func _err_raw(s: str): write(2, s as void*, s.len() as u64) end
+    else:
+        func _err_raw(s: str): write(2, s as void*, s.len() as u32) end
+    end
 end
 
 extern:


### PR DESCRIPTION
My regression from the wasm signature fix. Five of eight release jobs failed:

```
error[E012]: argument 3: cannot pass 'u64' to 'u32'
 --> std/console/console.salam:68:28
```

The declaration was split on pointer width, but the call site below it kept casting unconditionally:

```salam
func _err_raw(s: str): write(2, s as void*, s.len() as u64) end
```

On a 32-bit target the parameter is `u32`, and Salam rejects the u64 argument rather than narrowing it silently. That failed i686 and armhf directly, and took Linux, Windows and aarch64 with them through their cross-compile smoke tests. macOS and the x86_64 musl build passed because they are 64-bit, which is exactly why my host-only testing missed it.

## Fix

The call site splits the same way the declaration does.

## Checks

Reproduced first, since the failure is at sema and needs no cross toolchain:

```
salam build --target=i686-linux-musl   ->  E012, same line
```

Then type-checked every target the release cross-compiles to, plain and with spawn/join:

```
i686-linux-musl            sema ok
arm-linux-musleabihf       sema ok
x86_64-linux-musl          sema ok
aarch64-linux-musl         sema ok
x86_64-w64-windows-gnu     sema ok
wasm32-unknown-emscripten  sema ok
```

Host build fine, the stderr diagnostic path still prints, and `general exec errors cross` gives 695 passed, 0 failed.

Testing on the host only is what let this through; a width-dependent declaration needs the other width checked, and that is now cheap to do since sema catches it without a toolchain.