### PR TITLE
std: stop declaring libc write, let codegen own it

### DIFF
--- a/compiler/repl.salam
+++ b/compiler/repl.salam
@@ -148,7 +148,6 @@ else:
         func tcgetattr(fd: int, buf: void*): int
         func tcsetattr(fd: int, action: int, buf: void*): int
         func read(fd: int, buf: void*, n: u64): i64
-        func write(fd: int, buf: void*, n: u64): i64
     end
 end
 

--- a/std/console/console.salam
+++ b/std/console/console.salam
@@ -25,29 +25,6 @@ extern:
     func printf(fmt: str, ...): int
 end
 
-if SALAM_OS_WINDOWS:
-    extern:
-        func _write(fd: int, buf: void*, n: u32): int
-    end
-else:
-    // ssize_t and size_t are the pointer width, so the declaration has to
-    // follow it - same reason std/fs splits its syscall() decl. A u64 count
-    // on a 32-bit target makes this (i32, i32, i64) -> i64 where the real
-    // write is (i32, i32, i32) -> i32. An ELF link never notices; wasm-ld
-    // does, and answers with a stub that traps on the first call, which is
-    // how every diagnostic the online playground tried to print killed the
-    // module instead.
-    if SALAM_ARCH_X64 || SALAM_ARCH_ARM64:
-        extern:
-            func write(fd: int, buf: void*, n: u64): i64
-        end
-    else:
-        extern:
-            func write(fd: int, buf: void*, n: u32): i32
-        end
-    end
-end
-
 extern:
     func salam_tostr_i32(x: int): str: ret str.Clone(conv.FormatInt(x as i64)) end
     func salam_tostr_i64(x: i64): str: ret str.Clone(conv.FormatInt(x)) end
@@ -62,18 +39,18 @@ extern:
     end
 end
 
-if SALAM_OS_WINDOWS:
-    func _err_raw(s: str): _write(2, s as void*, s.len() as u32) end
-else:
-    // The cast has to track the declaration above: on a 32-bit target the
-    // count parameter is u32, and a u64 argument is a type error rather
-    // than a silent narrowing.
-    if SALAM_ARCH_X64 || SALAM_ARCH_ARM64:
-        func _err_raw(s: str): write(2, s as void*, s.len() as u64) end
-    else:
-        func _err_raw(s: str): write(2, s as void*, s.len() as u32) end
-    end
-end
+// `printerr`, rather than this module declaring write() itself. ssize_t and
+// size_t are the pointer width, so a hand-written declaration is only right
+// for one target - but the deeper problem is that it cannot be kept in step
+// with the one codegen emits into every module header. A bootstrap build
+// compiles this file's declaration from the tree while the header comes from
+// the seed compiler, so the two disagree whenever the seed predates a change
+// here, and C rejects the translation unit. The builtin has no such split:
+// codegen lowers it against whichever prelude it just emitted, so there is
+// exactly one declaration of write() per compilation and it is always the
+// right one. It does not recurse into salam_emit - print/printerr are
+// inlined C, not calls back into this module.
+func _err_raw(s: str): printerr s end
 
 extern:
     func salam_emit(s: str, err: int):

--- a/std/term/term.salam
+++ b/std/term/term.salam
@@ -55,7 +55,6 @@ end
 if SALAM_OS_WINDOWS:
     extern:
         func _isatty(fd: int): int
-        func _write(fd: int, buf: void*, n: u32): int
         func GetStdHandle(which: int): void*
         func GetConsoleMode(h: void*, mode: void*): int
         func SetConsoleMode(h: void*, mode: int): int
@@ -64,7 +63,6 @@ if SALAM_OS_WINDOWS:
 else:
     extern:
         func isatty(fd: int): int
-        func write(fd: int, buf: void*, n: u64): i64
         func ioctl(fd: int, req: u64, arg: void*): int
         func tcgetattr(fd: int, t: void*): int
         func tcsetattr(fd: int, act: int, t: void*): int
@@ -326,12 +324,15 @@ end
 @en "WriteErr"
 @fa "نوشتن خطا"
 @ar "کتابة خطأ"
+// `printerr`, not a hand-declared write(2). The count argument is ssize_t
+// and size_t sized, so a fixed-width declaration is right for one target
+// only - and it cannot be kept in step with the one codegen puts in every
+// module header, because a bootstrap build takes this file from the tree
+// and that header from the seed. codegen lowers the builtin against the
+// prelude it just emitted, so there is one declaration per compilation and
+// it always matches.
 pub func WriteErr(s: str):
-    if SALAM_OS_WINDOWS:
-        _n := _write(StderrFd, s as void*, s.len() as u32)
-    else:
-        _n := write(StderrFd, s as void*, s.len() as u64)
-    end
+    printerr s
 end
 
 @en "Flush"


### PR DESCRIPTION
The i686 release build failed to compile:

```
salam_mod_console.h:1168: error: conflicting types for 'write';
  have     'int32_t(int32_t, void *, uint32_t)'
salam_mod_jsgen.h:39: note: previous declaration
  'int64_t(int32_t, void *, uint64_t)'
```

## Not a width bug, a bootstrap skew

That job runs `build-selfhost.sh --seed=/work/seed/salam` inside an i386 container. The module header's prelude is emitted by the **seed** (released 0.3.6, always 64-bit), while `std/console` is compiled from **this tree**, where the previous fix split it on pointer width. Two compiler versions in one translation unit, disagreeing about one symbol.

No hand-written declaration can survive that. It is compiled by one version, while the header it has to match is emitted by another, so any change to it breaks the next bootstrap.

## Fix

Nothing in std declares libc `write` any more. `printerr` does the same job, and codegen lowers it against the prelude it just emitted, so there is exactly one declaration per compilation and it is correct for the target by construction. It does not recurse: print and printerr are inlined C, not calls back into `std/console`.

Three declarers removed:

- `std/console` - `_err_raw`
- `std/term` - `WriteErr`, stderr only, same treatment
- `compiler/repl` - declared it and never called it

## Checks

Built with a **0.3.5 seed**, which is the same skew the i686 job has. The generated C now carries one declaration:

```
extern int64_t write(int32_t, void *, uint64_t);      <- the prelude, alone
```

All cross targets compile under that old seed: i686, armhf, aarch64, mingw, wasm32. The stderr diagnostic path still prints. `general exec errors repl cross`: 698 passed, 0 failed.

## Note

`compiler/repl` still declares `read` with a 64-bit count, which has the same latent problem. It was not in the wasm-ld warnings, so it is being dead-stripped from the playground build today, and there is no builtin to replace it with. Left alone deliberately rather than churned during a release fix.