### PR TITLE
ci: read the signed-tag flag through env, not an expansion

### DIFF
--- a/.github/workflows/compiler-release.yml
+++ b/.github/workflows/compiler-release.yml
@@ -2567,6 +2567,11 @@ jobs:
           # Same token as the tag: with RELEASE_TOKEN set the release is
           # published by that account instead of github-actions[bot].
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          # Read through env rather than interpolated into the script below,
+          # which is the rule this file's header states and zizmor enforces:
+          # an expansion is pasted in as source text before the shell ever
+          # sees it, so a value carrying shell syntax would be executed.
+          TAG_WAS_SIGNED: ${{ steps.signtag.outputs.signed }}
         run: |
           set -eu
           shopt -s nullglob
@@ -2672,7 +2677,7 @@ jobs:
           # passing it alongside an existing ref makes gh create a second,
           # lightweight one and the signature is lost.
           TARGET_ARG="--target $GITHUB_SHA"
-          [ "${{ steps.signtag.outputs.signed }}" = "true" ] && TARGET_ARG=""
+          [ "$TAG_WAS_SIGNED" = "true" ] && TARGET_ARG=""
           # shellcheck disable=SC2086 # deliberately empty or two words
           gh release create "$TAG" \
             $TARGET_ARG \


### PR DESCRIPTION
Super-linter's zizmor audit:

```
info[template-injection]: code injection via template expansion
    --> .github/workflows/compiler-release.yml:2675:18
2675 |   [ "${{ steps.signtag.outputs.signed }}" = "true" ] && TARGET_ARG=""
     |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
```

Mine, from the signed-tag change. An expansion is pasted into the script as source text before the shell ever sees it, so a value carrying shell syntax would be executed rather than compared.

The value here is one this workflow writes itself, so it is not exploitable in practice, which is why zizmor rates it informational. But the file's own header states the rule the rest of it follows:

> inputs are only ever read via `env:` indirection, never interpolated into a `run:` script

so this was simply inconsistent with the convention it sits in.

Now passed as `TAG_WAS_SIGNED` in the step's `env:` and read as `$TAG_WAS_SIGNED`.

Swept the rest of the file: the only other `run:` blocks with an expansion use `github.workspace` and a job result, neither attacker-controllable, and zizmor reported exactly this one finding. YAML parses, step shellchecks clean.