### PR TITLE
release: name every asset for the architecture it holds

### DIFF
--- a/.github/workflows/compiler-release.yml
+++ b/.github/workflows/compiler-release.yml
@@ -478,7 +478,7 @@ jobs:
         run: |
           set -eu
           VERSION=$(tr -d ' \t\r\n' < VERSION)
-          DIST="salam-linux"
+          DIST="salam-linux-x86_64"
           mkdir -p "$DIST"
           cp salam "$DIST/salam"
           cp -r std "$DIST/std"
@@ -514,19 +514,19 @@ jobs:
               echo "sysroot. macOS targets are not supported (Apple SDK restrictions)."
             fi
           } > "$DIST/RUN-ME.txt"
-          zip -r "salam-${VERSION}-linux.zip" "$DIST" >/dev/null
+          zip -r "salam-${VERSION}-linux-x86_64.zip" "$DIST" >/dev/null
           # Same tree as the .zip, as a .tar.gz too: it is what Unix
           # reaches for, and it carries the executable bit on salam
           # without anyone having to chmod after unzipping.
-          tar -czf "salam-${VERSION}-linux.tar.gz" "$DIST"
-          ls -la "salam-${VERSION}-linux.zip" "salam-${VERSION}-linux.tar.gz"
+          tar -czf "salam-${VERSION}-linux-x86_64.tar.gz" "$DIST"
+          ls -la "salam-${VERSION}-linux-x86_64.zip" "salam-${VERSION}-linux-x86_64.tar.gz"
       - name: Upload versioned archive
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: salam-linux-zip
           path: |
-            salam-*-linux.zip
-            salam-*-linux.tar.gz
+            salam-*-linux-x86_64.zip
+            salam-*-linux-x86_64.tar.gz
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -589,7 +589,7 @@ jobs:
         run: |
           set -eu
           VERSION=$(tr -d ' \t\r\n' < VERSION)
-          DIST="salam-linux-musl"
+          DIST="salam-linux-x86_64-musl"
           mkdir -p "$DIST"
           cp salam "$DIST/salam"
           cp -r std "$DIST/std"
@@ -611,16 +611,16 @@ jobs:
             echo "and has no --jit. For that, use the glibc bundle on a host new enough"
             echo "to run it."
           } > "$DIST/RUN-ME.txt"
-          zip -r "salam-${VERSION}-linux-musl.zip" "$DIST" >/dev/null
-          tar -czf "salam-${VERSION}-linux-musl.tar.gz" "$DIST"
-          ls -la "salam-${VERSION}-linux-musl.zip" "salam-${VERSION}-linux-musl.tar.gz"
+          zip -r "salam-${VERSION}-linux-x86_64-musl.zip" "$DIST" >/dev/null
+          tar -czf "salam-${VERSION}-linux-x86_64-musl.tar.gz" "$DIST"
+          ls -la "salam-${VERSION}-linux-x86_64-musl.zip" "salam-${VERSION}-linux-x86_64-musl.tar.gz"
       - name: Upload versioned archive
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: salam-linux-musl-zip
           path: |
-            salam-*-linux-musl.zip
-            salam-*-linux-musl.tar.gz
+            salam-*-linux-x86_64-musl.zip
+            salam-*-linux-x86_64-musl.tar.gz
 
   build-macos:
     name: Build Salam for macOS
@@ -764,7 +764,7 @@ jobs:
         run: |
           set -eu
           VERSION=$(tr -d ' \t\r\n' < VERSION)
-          DIST="salam-mac"
+          DIST="salam-macos-arm64"
           mkdir -p "$DIST"
           cp salam "$DIST/salam"
           cp -r std "$DIST/std"
@@ -782,19 +782,19 @@ jobs:
             echo "is not redistributable, so linking uses Apple's toolchain. Cross-"
             echo "compiling FROM Linux/Windows TO macOS is likewise not supported."
           } > "$DIST/RUN-ME.txt"
-          zip -r "salam-${VERSION}-mac.zip" "$DIST" >/dev/null
+          zip -r "salam-${VERSION}-macos-arm64.zip" "$DIST" >/dev/null
           # Same tree as the .zip, as a .tar.gz too: it is what Unix
           # reaches for, and it carries the executable bit on salam
           # without anyone having to chmod after unzipping.
-          tar -czf "salam-${VERSION}-mac.tar.gz" "$DIST"
-          ls -la "salam-${VERSION}-mac.zip" "salam-${VERSION}-mac.tar.gz"
+          tar -czf "salam-${VERSION}-macos-arm64.tar.gz" "$DIST"
+          ls -la "salam-${VERSION}-macos-arm64.zip" "salam-${VERSION}-macos-arm64.tar.gz"
       - name: Upload versioned archive
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: salam-macos-zip
           path: |
-            salam-*-mac.zip
-            salam-*-mac.tar.gz
+            salam-*-macos-arm64.zip
+            salam-*-macos-arm64.tar.gz
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -1403,20 +1403,20 @@ jobs:
         shell: bash
         run: |
           VERSION=$(tr -d ' \t\r\n' < VERSION)
-          7z a -tzip "salam-${VERSION}-windows.zip" salam-windows >/dev/null
+          7z a -tzip "salam-${VERSION}-windows-x86_64.zip" salam-windows >/dev/null
           # Same tree as the .zip, as a .tar.gz too: it is what Unix
           # reaches for, and it carries the executable bit on salam
           # without anyone having to chmod after unzipping.
-          tar -czf "salam-${VERSION}-windows.tar.gz" salam-windows
-          ls -la "salam-${VERSION}-windows.zip" "salam-${VERSION}-windows.tar.gz"
+          tar -czf "salam-${VERSION}-windows-x86_64.tar.gz" salam-windows
+          ls -la "salam-${VERSION}-windows-x86_64.zip" "salam-${VERSION}-windows-x86_64.tar.gz"
 
       - name: Upload self-contained bundle
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: salam-windows-bundle
           path: |
-            salam-*-windows.zip
-            salam-*-windows.tar.gz
+            salam-*-windows-x86_64.zip
+            salam-*-windows-x86_64.tar.gz
 
       - name: Upload salam.exe
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -2634,7 +2634,7 @@ jobs:
             echo "Check a single file:"
             echo ""
             echo '```'
-            echo "sha256sum -c salam-${VERSION}-linux.zip.sha256"
+            echo "sha256sum -c salam-${VERSION}-linux-x86_64.zip.sha256"
             echo '```'
             echo ""
             echo "Check everything you downloaded:"
@@ -2648,11 +2648,11 @@ jobs:
             echo ""
             echo "### Which Linux x86_64 build"
             echo ""
-            echo "\`linux\` is the flagship: embedded LLVM, LLD and sysroots, so it"
+            echo "\`linux-x86_64\` is the flagship: embedded LLVM, LLD and sysroots, so"
             echo "cross-compiles and JITs with nothing else installed. It links glibc"
             echo "and needs ${GLIBC_FLOOR_NOTE} or newer."
             echo ""
-            echo "\`linux-musl\` is fully static and loads no libc at all, so it runs on"
+            echo "\`linux-x86_64-musl\` is fully static and loads no libc at all, so it"
             echo "any x86_64 Linux - Amazon Linux, RHEL, Debian stable, Alpine, slim"
             echo "containers. It has no embedded LLVM, so no cross-compiling and no JIT."
             echo ""

--- a/install.sh
+++ b/install.sh
@@ -1013,15 +1013,16 @@ else
     linux)
         case "$ARCH" in
         x86_64 | amd64)
-            # linux-musl is the fully static build: no libc of any kind is
-            # loaded, so it runs anywhere. Order decides which is installed,
-            # and every name is probed against the real release, so listing
-            # both means a release that publishes only one still resolves.
+            # linux-x86_64-musl is the fully static build: no libc of any
+            # kind is loaded, so it runs anywhere. Order decides which is
+            # installed, and every name is probed against the real release,
+            # so the pre-0.3.7 spellings stay in the list and an older
+            # release still resolves.
             if [ "$LIBC" = "musl" ] || [ "$LIBC" = "unknown" ] ||
                 glibc_below_floor; then
-                PLATFORMS="linux-musl linux linux-x86_64"
+                PLATFORMS="linux-x86_64-musl linux-musl linux-x86_64 linux"
             else
-                PLATFORMS="linux linux-musl linux-x86_64"
+                PLATFORMS="linux-x86_64 linux linux-x86_64-musl linux-musl"
             fi
             ;;
         i386 | i486 | i586 | i686 | x86) PLATFORMS="linux-i686" ;;
@@ -1035,8 +1036,13 @@ else
         ;;
     mac)
         case "$ARCH" in
-        arm64 | aarch64) PLATFORMS="mac mac-aarch64 mac-arm64" ;;
-        *) PLATFORMS="mac mac-x86_64" ;;
+        # Only Apple Silicon is published. The old "mac" asset was an
+        # arm64 build under a name that did not say so, which an Intel Mac
+        # downloaded and then could not exec; leaving it out of the Intel
+        # list turns that into an honest "nothing published for this
+        # platform" before anything is fetched.
+        arm64 | aarch64) PLATFORMS="macos-arm64 mac-arm64 mac-aarch64 mac" ;;
+        *) PLATFORMS="macos-x86_64 mac-x86_64" ;;
         esac
         ;;
     bsd)


### PR DESCRIPTION
Three assets said nothing about their CPU while every sibling did:

```
salam-linux            <- x86_64, unsaid
salam-linux-aarch64
salam-linux-armhf
salam-linux-i686
salam-mac              <- arm64, unsaid
salam-windows-i686.exe
```

## The mac one is a real bug, not just vague

The runner is `macos-26-arm64`, so that asset is **Apple Silicon only**. An Intel Mac user downloading `salam-0.3.7-mac.zip` got an arm64 binary and a CPU-type error at exec, with nothing in the name to warn them.

## Renames

| before | after |
|---|---|
| `linux` | `linux-x86_64` |
| `linux-musl` | `linux-x86_64-musl` |
| `mac` | `macos-arm64` |
| `windows` | `windows-x86_64` |

`linux-i686`, `linux-aarch64`, `linux-armhf` and `windows-i686` were already explicit and are unchanged.

## install.sh

New names are probed first, old ones stay in the list, so an older release still resolves and nobody's install breaks:

```
linux-x86_64 linux linux-x86_64-musl linux-musl
macos-arm64 mac-arm64 mac-aarch64 mac
```

Intel Macs now list only `macos-x86_64 mac-x86_64`, neither of which is published, so they get an honest "no build for this platform" before downloading rather than a binary that cannot run.

## One thing deliberately left alone

The Windows job's working directory stays `salam-windows`. It is shared with the tcc cache path, the PATH the tests run under and the smoke steps, so renaming it would have touched seven unrelated places for a cosmetic gain. Only the published archive carries the architecture.

## Checks

Workflow YAML parses, `install.sh` shellchecks clean, and the zip/tar parity gate pairs all nine archives under the new names.