### PR TITLE
release: put every asset on one naming pattern

### DIFF
--- a/.github/workflows/_reusable-android-build.yml
+++ b/.github/workflows/_reusable-android-build.yml
@@ -136,7 +136,7 @@ jobs:
 
           count=0
           while IFS=$'\t' read -r out_file abi; do
-            cp "$apk_dir/$out_file" "dist/salam-application-v${vname}-${vcode}-${abi}.apk"
+            cp "$apk_dir/$out_file" "dist/salam-${vname}-android-${abi}.apk"
             count=$((count + 1))
           done < <(jq -r '.elements[] | [.outputFile, ((.filters[]? | select(.filterType=="ABI") | .value) // "universal")] | @tsv' "$meta")
           if [ "$count" -eq 0 ]; then
@@ -146,7 +146,7 @@ jobs:
 
           aab_src=$(find "$aab_dir" -maxdepth 1 -name '*.aab' | head -1)
           [ -n "$aab_src" ] || { echo "::error::no .aab found in $aab_dir"; exit 1; }
-          cp "$aab_src" "dist/salam-application-v${vname}-${vcode}.aab"
+          cp "$aab_src" "dist/salam-${vname}-android.aab"
 
           {
             echo "vname=$vname"

--- a/.github/workflows/compiler-release.yml
+++ b/.github/workflows/compiler-release.yml
@@ -2575,20 +2575,17 @@ jobs:
         run: |
           set -eu
           shopt -s nullglob
+          # Every published name is salam-<version>-<what>.<ext>, so these
+          # globs stay short. The bare per-platform binaries that used to be
+          # listed here commented out are gone: the bundles supersede them,
+          # and a name like "salam-linux" said nothing about its CPU.
           candidates=(
-            # release/salam-linux
-            # release/salam-mac
-            # release/salam-windows.exe
-            # release/salam-linux-i686
-            # release/salam-windows-i686.exe
-            # release/salam-linux-aarch64
-            # release/salam-linux-armhf
             release/salam-*.zip
             release/salam-*.tar.gz
             release/salam-*-stdlib-index.json
             release/salam-*-stdlib-doc.html
-            release/salam-application-*.aab
-            release/salam-application-*.apk
+            release/salam-*-android.aab
+            release/salam-*-android-*.apk
           )
           assets=()
           for c in "${candidates[@]}"; do


### PR DESCRIPTION
Follow-up to #1623. After that, one group was still off the pattern:

```
salam-application-v0.3.7-307.aab             <- different prefix, a v, an android version code
salam-application-v0.3.7-307-universal.apk
```

Everything else is `salam-<version>-<what>.<ext>`. These are now `salam-0.3.7-android.aab` and `salam-0.3.7-android-universal.apk`.

The `307` was the Android versionCode, derived from the version, so it repeated information the name already carried.

## The whole release now

```
salam-0.3.7-linux-x86_64.zip / .tar.gz
salam-0.3.7-linux-x86_64-musl.zip / .tar.gz
salam-0.3.7-linux-i686.zip / .tar.gz
salam-0.3.7-linux-aarch64.zip / .tar.gz
salam-0.3.7-linux-armhf.zip / .tar.gz
salam-0.3.7-macos-arm64.zip / .tar.gz
salam-0.3.7-windows-x86_64.zip / .tar.gz
salam-0.3.7-windows-i686.zip / .tar.gz
salam-0.3.7-stdlib.zip / .tar.gz
salam-0.3.7-stdlib-index.json
salam-0.3.7-stdlib-doc.html
salam-0.3.7-android.aab
salam-0.3.7-android-universal.apk
SHA256SUMS  + a .sha256 beside every file
```

One pattern throughout: name, version, what it is, extension. Sorted alphabetically it groups by platform on its own.

## Also removed

Seven commented-out bare binaries in the publish list (`salam-linux`, `salam-mac`, `salam-windows.exe`, ...). They have not been published for some time, and those are exactly the names that said nothing about which CPU they were for.

## Left alone

`app-android-pr-build.yml` still names its artifacts `salam-application-pr123-<sha>.apk`. Those are PR previews, never published in a release, so they are a separate naming domain and renaming them would be churn.

The keystore temp file keeps its name too - it is a runner-local path, not an asset.

## Checks

Both workflows parse. Simulated a full release through the real publish step: 23 assets plus sidecars, every one matching the pattern, and the zip/tar parity gate pairs all nine archives.